### PR TITLE
Do not increase expected indent part way through a multi-line conditi…

### DIFF
--- a/src/vscode/LinterWorker.js
+++ b/src/vscode/LinterWorker.js
@@ -296,7 +296,7 @@ module.exports = class LinterWorker {
       /**
        * When the document changes, we want to fetch the updated errors.
        */
-      vscode.workspace.onDidChangeTextDocument(async editor => {So
+      vscode.workspace.onDidChangeTextDocument(async editor => {
         if (editor) {
           const document = editor.document;
           if (document.languageId === `rpgle`) {

--- a/tests/suite/linter.js
+++ b/tests/suite/linter.js
@@ -7,6 +7,71 @@ const Linter = require(`../../src/language/linter`);
 
 const URI = vscode.Uri.parse(`source.rpgle`);
 
+exports.linter_indent_multi_1 = async () => {
+  const lines = [
+    `**FREE`,
+    `Begsr shouldBeGood;`,
+    `  If a`,
+    `  and b`,
+    `      or c;`,
+    `    clear x;`,
+    `  Endif;`,
+    `  If a // comment`,
+    `  and b // comment`,
+    `      or c; // comment`,
+    `    clear x;`,
+    `  Elseif x`,
+    `  and y`,
+    `      or z;`,
+    `    Dou not x`,
+    `    and not y`,
+    `    and not z;`,
+    `      clear z;`,
+    `    Enddo;`,
+    `  Endif;`,
+    `Endsr;`,
+    `Return;`
+  ].join(`\n`);
+ 
+  const parser = new Parser();
+  const cache = await parser.getDocs(URI, lines);
+  const { indentErrors } = Linter.getErrors(lines, {
+    indent: 2
+  }, cache);
+  
+  assert.strictEqual(indentErrors.length, 0, `There should be no errors`);
+};
+
+exports.linter_indent_multi_2 = async () => {
+  const lines = [
+    `**FREE`,
+    `Begsr shouldError;`,
+    `  If a`,
+    ` and b`,
+    `      or c;`,
+    `     clear x;`,
+    `  Endif;`,
+    `Endsr;`,
+    `Return;`
+  ].join(`\n`);
+ 
+  const parser = new Parser();
+  const cache = await parser.getDocs(URI, lines);
+  const { indentErrors } = Linter.getErrors(lines, {
+    indent: 2
+  }, cache);
+  
+  assert.strictEqual(indentErrors.length, 2, `There should be 2 errors`);
+
+  assert.strictEqual(indentErrors[0].line, 3, `First error should be index 3`);
+  assert.strictEqual(indentErrors[0].currentIndent, 1, `Actual indent should be 1`);
+  assert.strictEqual(indentErrors[0].expectedIndent, 2, `Expected indent should be 2`);
+
+  assert.strictEqual(indentErrors[1].line, 5, `Second error should be index 5`);
+  assert.strictEqual(indentErrors[1].currentIndent, 5, `Actual indent should be 5`);
+  assert.strictEqual(indentErrors[1].expectedIndent, 4, `Expected indent should be 4`);
+};
+
 exports.linter1_indent = async () => {
   const lines = [
     `**FREE`,


### PR DESCRIPTION
Do not require continued lines to be indented.
The problem is that we are incrementing the expected indent as soon as we find a conditional (i.e. IF, WHEN) even if it's a continued line.  

### Changes
Defer incrementing the expected indent until we reach the end of the conditional statement.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [x] **for feature PRs**: PR only includes one feature enhancement.
