### PR TITLE
File definitions seperated 

### DIFF
--- a/src/language/models/cache.js
+++ b/src/language/models/cache.js
@@ -10,7 +10,7 @@ const inds = [...Array(98).keys(), `LR`, `KL`].map(val => `IN${val.toString().pa
 module.exports = class Cache {
   /**
    * 
-   * @param {{subroutines?: Declaration[], procedures?: Declaration[], variables?: Declaration[], structs?: Declaration[], constants?: Declaration[], indicators?: Declaration[]}} cache 
+   * @param {{subroutines?: Declaration[], procedures?: Declaration[], files?: Declaration[], variables?: Declaration[], structs?: Declaration[], constants?: Declaration[], indicators?: Declaration[]}} cache 
    */
   constructor(cache = {}) {
     /** @type {Declaration[]} */
@@ -18,6 +18,9 @@ module.exports = class Cache {
 
     /** @type {Declaration[]} */
     this.procedures = cache.procedures || [];
+
+    /** @type {Declaration[]} */
+    this.files = cache.files || [];
 
     /** @type {Declaration[]} */
     this.variables = cache.variables || [];
@@ -42,6 +45,7 @@ module.exports = class Cache {
         subroutines: [...this.subroutines, ...second.subroutines],
         procedures: [...this.procedures, ...second.procedures],
         variables: [...this.variables, ...second.variables],
+        files: [...this.files, ...second.files],
         structs: [...this.structs, ...second.structs],
         constants: [...this.constants, ...second.constants],
         indicators: [...this.indicators, ...second.indicators]
@@ -55,9 +59,11 @@ module.exports = class Cache {
    * @returns {String[]}
    */
   getNames() {
+    let fileStructNames = [...this.files.map(file => file.subItems.map(sub => sub.name))];
     return [
-      ...this.constants.map(def => def.name), 
-      ...this.procedures.map(def => def.name), 
+      ...this.constants.map(def => def.name),
+      ...this.procedures.map(def => def.name),
+      ...this.files.map(def => def.name),
       ...this.subroutines.map(def => def.name), 
       ...this.variables.map(def => def.name),
       ...this.structs.map(def => def.name),

--- a/src/language/models/cache.js
+++ b/src/language/models/cache.js
@@ -59,11 +59,12 @@ module.exports = class Cache {
    * @returns {String[]}
    */
   getNames() {
-    let fileStructNames = [...this.files.map(file => file.subItems.map(sub => sub.name))];
+    const fileStructNames = this.files.map(file => file.subItems.map(sub => sub.name)).flat();
     return [
       ...this.constants.map(def => def.name),
       ...this.procedures.map(def => def.name),
       ...this.files.map(def => def.name),
+      ...fileStructNames,
       ...this.subroutines.map(def => def.name), 
       ...this.variables.map(def => def.name),
       ...this.structs.map(def => def.name),
@@ -77,17 +78,21 @@ module.exports = class Cache {
    */
   find(name) {
     name = name.toUpperCase();
+    const fileStructs = this.files.map(file => file.subItems).flat();
+    const allStructs = [...fileStructs, ...this.structs];
+
     const possibles = [
       ...this.constants.filter(def => def.name.toUpperCase() === name), 
       ...this.procedures.filter(def => def.name.toUpperCase() === name), 
-      ...this.subroutines.filter(def => def.name.toUpperCase() === name), 
+      ...this.files.filter(def => def.name.toUpperCase() === name),
+      ...allStructs.filter(def => def.name.toUpperCase() === name),
+      ...this.subroutines.filter(def => def.name.toUpperCase() === name),
       ...this.variables.filter(def => def.name.toUpperCase() === name),
-      ...this.structs.filter(def => def.name.toUpperCase() === name),
       ...this.indicators.filter(def => def.name.toUpperCase() === name),
     ];
 
-    if (this.structs.length > 0) {
-      this.structs.filter(def => !def.keywords.includes(`QUALIFIED`)).forEach(def => {
+    if (allStructs.length > 0 && possibles.length === 0) {
+      allStructs.filter(def => !def.keywords.includes(`QUALIFIED`)).forEach(def => {
         possibles.push(...def.subItems.filter(sub => sub.name.toUpperCase() === name));
       });
     }

--- a/src/language/models/declaration.js
+++ b/src/language/models/declaration.js
@@ -4,7 +4,7 @@ const Cache = require(`./cache`);
 module.exports = class Declaration {
   /**
    * 
-   * @param {"procedure"|"subroutine"|"struct"|"subitem"|"variable"|"constant"} type 
+   * @param {"procedure"|"subroutine"|"file"|"struct"|"subitem"|"variable"|"constant"} type 
    */
   constructor(type) {
     this.type = type;

--- a/src/vscode/LanguageWorker.js
+++ b/src/vscode/LanguageWorker.js
@@ -472,7 +472,10 @@ module.exports = class LanguageWorker {
           return refs;
         }
       }),
-
+      
+      /**
+       * Provides content assist when writing code
+       */
       vscode.languages.registerCompletionItemProvider({language: `rpgle` }, {
         provideCompletionItems: async (document, position, token, context) => {
           const text = document.getText();
@@ -547,54 +550,88 @@ module.exports = class LanguageWorker {
               }
 
             } else {
-              for (const procedure of doc.procedures) {
-                item = new vscode.CompletionItem(`${procedure.name}`, vscode.CompletionItemKind.Function);
-                item.insertText = new vscode.SnippetString(`${procedure.name}(${procedure.subItems.map((parm, index) => `\${${index+1}:${parm.name}}`).join(`:`)})\$0`)
-                item.detail = procedure.keywords.join(` `);
-                item.documentation = procedure.description;
-                items.push(item);
-              }
+              /**
+               * @param {Cache} localCache 
+               */
+              const expandScope = (localCache) => {
+                for (const procedure of localCache.procedures) {
+                  item = new vscode.CompletionItem(`${procedure.name}`, vscode.CompletionItemKind.Function);
+                  item.insertText = new vscode.SnippetString(`${procedure.name}(${procedure.subItems.map((parm, index) => `\${${index+1}:${parm.name}}`).join(`:`)})\$0`)
+                  item.detail = procedure.keywords.join(` `);
+                  item.documentation = procedure.description;
+                  items.push(item);
+                }
+  
+                for (const subroutine of localCache.subroutines) {
+                  item = new vscode.CompletionItem(`${subroutine.name}`, vscode.CompletionItemKind.Function);
+                  item.insertText = new vscode.SnippetString(`${subroutine.name}\$0`);
+                  item.documentation = subroutine.description;
+                  items.push(item);
+                }
+  
+                for (const variable of localCache.variables) {
+                  item = new vscode.CompletionItem(`${variable.name}`, vscode.CompletionItemKind.Variable);
+                  item.insertText = new vscode.SnippetString(`${variable.name}\$0`);
+                  item.detail = variable.keywords.join(` `);
+                  item.documentation = variable.description;
+                  items.push(item);
+                }
+  
+                localCache.files.forEach(file => {
+                  item = new vscode.CompletionItem(`${file.name}`, vscode.CompletionItemKind.File);
+                  item.insertText = new vscode.SnippetString(`${file.name}\$0`);
+                  item.detail = file.keywords.join(` `);
+                  item.documentation = file.description;
+                  items.push(item);
 
-              for (const subroutine of doc.subroutines) {
-                item = new vscode.CompletionItem(`${subroutine.name}`, vscode.CompletionItemKind.Function);
-                item.insertText = new vscode.SnippetString(`${subroutine.name}\$0`);
-                item.documentation = subroutine.description;
-                items.push(item);
-              }
-
-              for (const variable of doc.variables) {
-                item = new vscode.CompletionItem(`${variable.name}`, vscode.CompletionItemKind.Variable);
-                item.insertText = new vscode.SnippetString(`${variable.name}\$0`);
-                item.detail = variable.keywords.join(` `);
-                item.documentation = variable.description;
-                items.push(item);
-              }
-
-              for (const struct of doc.structs) {
-                item = new vscode.CompletionItem(`${struct.name}`, vscode.CompletionItemKind.Struct);
-                item.insertText = new vscode.SnippetString(`${struct.name}\$0`);
-                item.detail = struct.keywords.join(` `);
-                item.documentation = struct.description;
-                items.push(item);
-
-                if (!struct.keyword[`QUALIFIED`]) {
-                  struct.subItems.forEach(subItem => {
-                    item = new vscode.CompletionItem(`${subItem.name}`, vscode.CompletionItemKind.Property);
-                    item.insertText = new vscode.SnippetString(`${subItem.name}\$0`);
-                    item.detail = subItem.keywords.join(` `);
-                    item.documentation = subItem.description + ` (${struct.name})`;
+                  for (const struct of file.subItems) {
+                    item = new vscode.CompletionItem(`${struct.name}`, vscode.CompletionItemKind.Struct);
+                    item.insertText = new vscode.SnippetString(`${struct.name}\$0`);
+                    item.detail = struct.keywords.join(` `);
+                    item.documentation = struct.description;
                     items.push(item);
-                  });
+    
+                    if (!struct.keyword[`QUALIFIED`]) {
+                      struct.subItems.forEach(subItem => {
+                        item = new vscode.CompletionItem(`${subItem.name}`, vscode.CompletionItemKind.Property);
+                        item.insertText = new vscode.SnippetString(`${subItem.name}\$0`);
+                        item.detail = subItem.keywords.join(` `);
+                        item.documentation = subItem.description + ` (${struct.name})`;
+                        items.push(item);
+                      });
+                    }
+                  }
+                });
+
+                for (const struct of localCache.structs) {
+                  item = new vscode.CompletionItem(`${struct.name}`, vscode.CompletionItemKind.Struct);
+                  item.insertText = new vscode.SnippetString(`${struct.name}\$0`);
+                  item.detail = struct.keywords.join(` `);
+                  item.documentation = struct.description;
+                  items.push(item);
+  
+                  if (!struct.keyword[`QUALIFIED`]) {
+                    struct.subItems.forEach(subItem => {
+                      item = new vscode.CompletionItem(`${subItem.name}`, vscode.CompletionItemKind.Property);
+                      item.insertText = new vscode.SnippetString(`${subItem.name}\$0`);
+                      item.detail = subItem.keywords.join(` `);
+                      item.documentation = subItem.description + ` (${struct.name})`;
+                      items.push(item);
+                    });
+                  }
+                }
+  
+                for (const constant of localCache.constants) {
+                  item = new vscode.CompletionItem(`${constant.name}`, vscode.CompletionItemKind.Constant);
+                  item.insertText = new vscode.SnippetString(`${constant.name}\$0`);
+                  item.detail = constant.keywords.join(` `);
+                  item.documentation = constant.description;
+                  items.push(item);
                 }
               }
 
-              for (const constant of doc.constants) {
-                item = new vscode.CompletionItem(`${constant.name}`, vscode.CompletionItemKind.Constant);
-                item.insertText = new vscode.SnippetString(`${constant.name}\$0`);
-                item.detail = constant.keywords.join(` `);
-                item.documentation = constant.description;
-                items.push(item);
-              }
+              expandScope(doc);
+
 
               if (currentProcedure) {
                 for (const subItem of currentProcedure.subItems) {
@@ -606,40 +643,7 @@ module.exports = class LanguageWorker {
                 }
 
                 if (currentProcedure.scope) {
-                  const scope = currentProcedure.scope;
-                  for (const variable of scope.variables) {
-                    item = new vscode.CompletionItem(`${variable.name}`, vscode.CompletionItemKind.Variable);
-                    item.insertText = new vscode.SnippetString(`${variable.name}\$0`);
-                    item.detail = variable.keywords.join(` `);
-                    item.documentation = variable.description;
-                    items.push(item);
-                  }
-  
-                  for (const struct of scope.structs) {
-                    item = new vscode.CompletionItem(`${struct.name}`, vscode.CompletionItemKind.Struct);
-                    item.insertText = new vscode.SnippetString(`${struct.name}\$0`);
-                    item.detail = struct.keywords.join(` `);
-                    item.documentation = struct.description;
-                    items.push(item);
-
-                    if (!struct.keyword[`QUALIFIED`]) {
-                      struct.subItems.forEach(subItem => {
-                        item = new vscode.CompletionItem(`${subItem.name}`, vscode.CompletionItemKind.Property);
-                        item.insertText = new vscode.SnippetString(`${subItem.name}\$0`);
-                        item.detail = subItem.keywords.join(` `);
-                        item.documentation = subItem.description + ` (${struct.name})`;
-                        items.push(item);
-                      });
-                    }
-                  }
-  
-                  for (const constant of scope.constants) {
-                    item = new vscode.CompletionItem(`${constant.name}`, vscode.CompletionItemKind.Constant);
-                    item.insertText = new vscode.SnippetString(`${constant.name}\$0`);
-                    item.detail = constant.keywords.join(` `);
-                    item.documentation = constant.description;
-                    items.push(item);
-                  }
+                  expandScope(currentProcedure.scope);
                 }
               }
             }

--- a/src/vscode/LanguageWorker.js
+++ b/src/vscode/LanguageWorker.js
@@ -251,6 +251,46 @@ module.exports = class LanguageWorker {
                   ))
               );
 
+              scope.files
+                .filter(struct => struct.position && struct.position.path === currentPath)
+                .forEach(file => {
+                  const fileDef = new vscode.DocumentSymbol(
+                    file.name,
+                    file.keywords.join(` `).trim(),
+                    vscode.SymbolKind.File,
+                    new vscode.Range(file.position.line, 0, file.position.line, 0),
+                    new vscode.Range(file.position.line, 0, file.position.line, 0)
+                  );
+
+                  file.subItems
+                    .filter(recordFormat => recordFormat.position && recordFormat.position.path === currentPath)
+                    .forEach(recordFormat => {
+                      const recordFormatDef = new vscode.DocumentSymbol(
+                        recordFormat.name,
+                        recordFormat.keywords.join(` `).trim(),
+                        vscode.SymbolKind.Struct,
+                        new vscode.Range(recordFormat.position.line, 0, recordFormat.position.line, 0),
+                        new vscode.Range(recordFormat.position.line, 0, recordFormat.position.line, 0)
+                      );
+  
+                      recordFormatDef.children.push(
+                        ...recordFormat.subItems
+                          .filter(subitem => subitem.position && subitem.position.path === currentPath)
+                          .map(subitem => new vscode.DocumentSymbol(
+                            subitem.name,
+                            subitem.keywords.join(` `).trim(),
+                            vscode.SymbolKind.Property,
+                            new vscode.Range(subitem.position.line, 0, subitem.position.line, 0),
+                            new vscode.Range(subitem.position.line, 0, subitem.position.line, 0)
+                          ))
+                      );
+
+                      fileDef.children.push(recordFormatDef);
+                    });
+
+                  currentScopeDefs.push(fileDef);
+                });
+
               scope.structs
                 .filter(struct => struct.position && struct.position.path === currentPath)
                 .forEach(struct => {

--- a/tests/suite/fixed.js
+++ b/tests/suite/fixed.js
@@ -23,6 +23,7 @@ exports.fixed1 = async () => {
   const parser = new Parser();
   const cache = await parser.getDocs(uri, lines);
 
+  assert.strictEqual(cache.files.length, 1);
   assert.strictEqual(cache.variables.length, 2, `Expect length of 2`);
 
   const wkCorp = cache.variables[0];


### PR DESCRIPTION
### Changes

Previously file definitions were expanded and each record format became a struct. This was fine, but as we add more complex parsing, we need the files grouped. This adds a new `files` array prop to `Cache`, each definition is a file and below that contain the structs (record formats) inside of that file.

This doesn't do a lot for the linter since we don't have a way to scan local DDS or SQL yet, but mostly affects the language tools as part of VS Code.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [x] **for feature PRs**: PR only includes one feature enhancement.
