### PR TITLE
Feature/rename

### DIFF
--- a/src/language/generic.js
+++ b/src/language/generic.js
@@ -115,6 +115,7 @@ module.exports = class {
   /**
    * @param {vscode.TextDocument} document
    * @param {IssueRange} error 
+   * @returns {vscode.Range}
    */
   static calculateOffset(document, error) {
     const offset = error.offset;

--- a/src/language/linter.js
+++ b/src/language/linter.js
@@ -872,6 +872,10 @@ module.exports = class Linter {
                       }
 
                       if (rules.CollectReferences) {
+                        if (statement[i-1] && statement[i-1].type === `dot`) {
+                          break;
+                        }
+
                         let defRef;
                         if (currentProcedure) {
                           defRef = currentProcedure.scope.find(upperName);

--- a/src/language/linter.js
+++ b/src/language/linter.js
@@ -105,6 +105,11 @@ module.exports = class Linter {
       rules.CollectReferences = true;
     }
 
+    // Clear out all the old references.
+    if (rules.CollectReferences) {
+      globalScope.clearReferences();
+    }
+
     // Make all external refs uppercase.
     if (rules.NoExternalTo && rules.NoExternalTo.length) {
       rules.NoExternalTo = rules.NoExternalTo.map(val => val.toUpperCase());
@@ -912,13 +917,15 @@ module.exports = class Linter {
 
                                 // Find the subitem
                                 const subItemDef = defRef.subItems.find(subfield => subfield.name.toUpperCase() == subItemName);
-                                subItemDef.references.push({
-                                  range: new vscode.Range(
-                                    statementStart,
-                                    statementEnd
-                                  ),
-                                  offset: {position: subItemPart.position, length: subItemPart.position + subItemPart.value.length},
-                                });
+                                if (subItemDef) {
+                                  subItemDef.references.push({
+                                    range: new vscode.Range(
+                                      statementStart,
+                                      statementEnd
+                                    ),
+                                    offset: {position: subItemPart.position, length: subItemPart.position + subItemPart.value.length},
+                                  });
+                                }
                               }
                             }
                           }

--- a/src/language/linter.js
+++ b/src/language/linter.js
@@ -888,7 +888,39 @@ module.exports = class Linter {
                                 statementEnd
                               ),
                               offset: {position: part.position, length: part.position + part.value.length},
-                            })
+                            });
+                          }
+
+                          if (defRef.keyword[`QUALIFIED`]) {
+                            let nextPartIndex = i+1;
+
+                            // First, check if there is an array call here and skip over it
+                            if (statement[nextPartIndex].type === `openbracket`) {
+                              nextPartIndex = statement.findIndex((value, index) => index > nextPartIndex && value.type === `closebracket`);
+
+                              if (nextPartIndex >= 0) nextPartIndex++;
+                            }
+
+                            // Check if the next part is a dot
+                            if (statement[nextPartIndex] && statement[nextPartIndex].type === `dot`) {
+                              nextPartIndex++;
+
+                              // Check if the next part is a word
+                              if (statement[nextPartIndex] && statement[nextPartIndex].type === `word` && statement[nextPartIndex].value) {
+                                const subItemPart = statement[nextPartIndex];
+                                const subItemName = subItemPart.value.toUpperCase();
+
+                                // Find the subitem
+                                const subItemDef = defRef.subItems.find(subfield => subfield.name.toUpperCase() == subItemName);
+                                subItemDef.references.push({
+                                  range: new vscode.Range(
+                                    statementStart,
+                                    statementEnd
+                                  ),
+                                  offset: {position: subItemPart.position, length: subItemPart.position + subItemPart.value.length},
+                                });
+                              }
+                            }
                           }
                         }
                       }

--- a/src/language/models/cache.js
+++ b/src/language/models/cache.js
@@ -92,7 +92,7 @@ module.exports = class Cache {
     ];
 
     if (allStructs.length > 0 && possibles.length === 0) {
-      allStructs.filter(def => !def.keywords.includes(`QUALIFIED`)).forEach(def => {
+      allStructs.filter(def => def.keyword[`QUALIFIED`] !== true).forEach(def => {
         possibles.push(...def.subItems.filter(sub => sub.name.toUpperCase() === name));
       });
     }

--- a/src/language/models/cache.js
+++ b/src/language/models/cache.js
@@ -103,4 +103,23 @@ module.exports = class Cache {
       return null;
     }
   }
+
+  clearReferences() {
+    [...this.constants, ...this.files, ...this.procedures, ...this.subroutines, ...this.variables, ...this.structs].forEach(def => {
+      def.references = [];
+    });
+
+    this.procedures.forEach(proc => {
+      if (proc.scope) {
+        proc.scope.clearReferences()
+      }
+    });
+
+    const fileStructs = this.files.map(file => file.subItems).flat();
+    const allStructs = [...fileStructs, ...this.structs];
+
+    allStructs.forEach(struct => {
+      struct.subItems.forEach(sub => sub.references = [])
+    });
+  }
 }

--- a/src/vscode/LanguageWorker.js
+++ b/src/vscode/LanguageWorker.js
@@ -9,7 +9,7 @@ const Cache = require(`../language/models/cache`);
 
 const Output = require(`../output`);
 const { Parser } = require(`../parser`);
-const { Range } = require("../../tests/models/vscode");
+const Declaration = require(`../language/models/declaration`);
 
 module.exports = class LanguageWorker {
   /**
@@ -414,26 +414,9 @@ module.exports = class LanguageWorker {
 
       vscode.languages.registerRenameProvider({ language: `rpgle`}, {
         prepareRename: async (document, position, cancelToken) => {
-          return new vscode.Range(0, 0, 0, 0);
-        },
-        provideRenameEdits: async (document, position, newName, cancelToken) => {
-          return new vscode.WorkspaceEdit();
-        },
-      }),
-
-      /**
-       * This implements 'Find references' and 'Peek references' for RPGLE
-       */
-      vscode.languages.registerReferenceProvider({ language: `rpgle` }, {
-        provideReferences: async (document, position, context, token) => {
-
-          /** @type {vscode.Location[]} */
-          let refs = [];
-
           const range = document.getWordRangeAtPosition(position);
           const word = document.getText(range).toUpperCase();
-            
-          const lineNumber = position.line;
+
           const isFree = (document.getText(new vscode.Range(0, 0, 0, 6)).toUpperCase() === `**FREE`);
           if (isFree) {
             const docs = await Parser.getDocs(document.uri);
@@ -446,35 +429,87 @@ module.exports = class LanguageWorker {
             }, {
               CollectReferences: true,
             }, docs);
+            
+            const currentPath = document.uri.path;
+            const definition = await LanguageWorker.findDefintion(document, position, word);
 
-            // If they're typing inside of a procedure, let's get the stuff from there too
-            const currentProcedure = docs.procedures.find(proc => lineNumber >= proc.range.start && lineNumber <= proc.range.end);
-
-            if (currentProcedure) {
-              const localDef = currentProcedure.scope.find(word);
-
-              if (localDef) {
-                localDef.references.forEach(ref => {
-                  refs.push(new vscode.Location(
-                    document.uri, 
-                    Generic.calculateOffset(document, ref)
-                  ))
-                });
+            if (definition) {
+              if (definition.position && definition.position.path === currentPath) {
+                // We don't store the defintion range, just line number
+                const defIndex = document.lineAt(definition.position.line).text.indexOf(definition.name);
+                return {
+                  range: new vscode.Range(definition.position.line, defIndex, definition.position.line, defIndex+definition.name.length),
+                  placeholder: definition.name
+                };
               }
             }
+          }
 
-            // Otherwise, maybe it's a global variable
-            if (refs.length === 0) {
-              const globalDef = docs.find(word);
+          return undefined;
+        },
+        provideRenameEdits: async (document, position, newName, cancelToken) => {
+          // We assume it is **free at this point.
+          const range = document.getWordRangeAtPosition(position);
+          const word = document.getText(range).toUpperCase();
 
-              if (globalDef) {
-                globalDef.references.forEach(ref => {
+          const docs = await Parser.getDocs(document.uri);
+          const text = document.getText();
+
+          // Updates docs
+          Linter.getErrors({
+            uri: document.uri,
+            content: text
+          }, {
+            CollectReferences: true,
+          }, docs);
+          
+          const currentPath = document.uri.path;
+          const definition = await LanguageWorker.findDefintion(document, position, word);
+
+          if (definition) {
+            if (definition.position && definition.position.path === currentPath) {
+              const edits = new vscode.WorkspaceEdit();
+              // We don't store the defintion range, just line number
+              const defIndex = document.lineAt(definition.position.line).text.indexOf(definition.name);
+
+              edits.replace(document.uri, new vscode.Range(definition.position.line, defIndex, definition.position.line, defIndex+definition.name.length), newName);
+              definition.references.forEach(ref => {
+                console.log(ref.range);
+                edits.replace(document.uri, Generic.calculateOffset(document, ref), newName);
+              })
+
+              return edits;
+            }
+          }
+        },
+      }),
+
+      /**
+       * This implements 'Find references' and 'Peek references' for RPGLE
+       */
+      vscode.languages.registerReferenceProvider({ language: `rpgle` }, {
+        provideReferences: async (document, position, context, token) => {
+          /** @type {vscode.Location[]} */
+          let refs = [];
+
+          const range = document.getWordRangeAtPosition(position);
+          const word = document.getText(range).toUpperCase();
+            
+          const isFree = (document.getText(new vscode.Range(0, 0, 0, 6)).toUpperCase() === `**FREE`);
+          if (isFree) {
+            try {
+              const declaration = await LanguageWorker.findDefintion(document, position, word);
+
+              if (declaration) {
+                declaration.references.forEach(ref => {
                   refs.push(new vscode.Location(
                     document.uri, 
                     Generic.calculateOffset(document, ref)
                   ))
                 });
               }
+            } catch (e) {
+              console.log(e);
             }
           } else {
             vscode.window.showInformationMessage(`You can only use 'Find references' with RPGLE free-format (**FREE)`);
@@ -664,5 +699,43 @@ module.exports = class LanguageWorker {
         }
       }, `.`),
     )
+  }
+
+  /**
+   * 
+   * @param {vscode.TextDocument} document 
+   * @param {vscode.Position} currentPosition 
+   * @param {string} word 
+   * @returns {Promise<Declaration>}
+   */
+  static async findDefintion(document, currentPosition, word) {
+    const lineNumber = currentPosition.line;
+    const docs = await Parser.getDocs(document.uri);
+    const text = document.getText();
+
+    // Updates docs
+    Linter.getErrors({
+      uri: document.uri,
+      content: text
+    }, {
+      CollectReferences: true,
+    }, docs);
+
+    // If they're typing inside of a procedure, let's get the stuff from there too
+    const currentProcedure = docs.procedures.find(proc => lineNumber >= proc.range.start && lineNumber <= proc.range.end);
+
+    if (currentProcedure) {
+      const localDef = currentProcedure.scope.find(word);
+
+      if (localDef) {
+        return localDef;
+      }
+    }
+
+    const globalDef = docs.find(word);
+
+    if (globalDef) {
+      return globalDef;
+    }
   }
 }

--- a/src/vscode/LanguageWorker.js
+++ b/src/vscode/LanguageWorker.js
@@ -9,6 +9,7 @@ const Cache = require(`../language/models/cache`);
 
 const Output = require(`../output`);
 const { Parser } = require(`../parser`);
+const { Range } = require("../../tests/models/vscode");
 
 module.exports = class LanguageWorker {
   /**
@@ -410,6 +411,15 @@ module.exports = class LanguageWorker {
           }
         }}
       ),
+
+      vscode.languages.registerRenameProvider({ language: `rpgle`}, {
+        prepareRename: async (document, position, cancelToken) => {
+          return new vscode.Range(0, 0, 0, 0);
+        },
+        provideRenameEdits: async (document, position, newName, cancelToken) => {
+          return new vscode.WorkspaceEdit();
+        },
+      }),
 
       /**
        * This implements 'Find references' and 'Peek references' for RPGLE

--- a/src/vscode/LanguageWorker.js
+++ b/src/vscode/LanguageWorker.js
@@ -445,7 +445,7 @@ module.exports = class LanguageWorker {
             }
           }
 
-          return undefined;
+          throw new Error(`Unable to find variable definition.`);
         },
         provideRenameEdits: async (document, position, newName, cancelToken) => {
           // We assume it is **free at this point.

--- a/tests/suite/linter.js
+++ b/tests/suite/linter.js
@@ -2427,6 +2427,10 @@ exports.linter38_subrefs = async () => {
     `    qualsubA zoned(5);`,
     `end-ds;`,
     ``,
+    `dcl-ds qualDimStructYup Qualified Dim(2);`,
+    `    boopABC zoned(5);`,
+    `end-ds;`,
+    ``,
     `localVarYes = 'Y';`,
     `procYes();`,
     ``,
@@ -2434,6 +2438,10 @@ exports.linter38_subrefs = async () => {
     `structYesAlso = 'Really yes';`,
     ``,
     `qualStructYes.qualsubA = 5;`,
+    ``,
+    `qualDimStructYup(1).boopabc = 5;`,
+    `qualDimStructYup(localVarForProc).boopAbc = 5;`,
+    `qualDimStructYup(localVarForProc - 1).boopABC = 5;`,
     ``,
     `return;`,
     ``,
@@ -2483,7 +2491,7 @@ exports.linter38_subrefs = async () => {
   const subfa = cache.find(`subfa`);
   assert.strictEqual(subfa.references.length, 1);
   assert.deepStrictEqual(subfa.references[0], {
-    range: new vscode.Range(29, 0, 29, 14),
+    range: new vscode.Range(33, 0, 33, 14),
     offset: {
       position: 0,
       length: 5
@@ -2493,7 +2501,7 @@ exports.linter38_subrefs = async () => {
   const structYesAlso = cache.find(`structYesAlso`);
   assert.strictEqual(structYesAlso.references.length, 1);
   assert.deepStrictEqual(structYesAlso.references[0], {
-    range: new vscode.Range(30, 0, 30, 28),
+    range: new vscode.Range(34, 0, 34, 28),
     offset: {
       position: 0,
       length: 13
@@ -2507,7 +2515,7 @@ exports.linter38_subrefs = async () => {
   const qualStructYes = cache.find(`qualStructYes`);
   assert.strictEqual(qualStructYes.references.length, 1);
   assert.deepStrictEqual(qualStructYes.references[0], {
-    range: new vscode.Range(32, 0, 32, 26),
+    range: new vscode.Range(36, 0, 36, 26),
     offset: {
       position: 0,
       length: 13
@@ -2518,7 +2526,7 @@ exports.linter38_subrefs = async () => {
   assert.strictEqual(qualsubA.name, `qualsubA`);
   assert.strictEqual(qualsubA.references.length, 1);
   assert.deepStrictEqual(qualsubA.references[0], {
-    range: new vscode.Range(32, 0, 32, 26),
+    range: new vscode.Range(36, 0, 36, 26),
     offset: {
       position: 14,
       length: 22
@@ -2531,7 +2539,7 @@ exports.linter38_subrefs = async () => {
   const localStructYes = subProc.find(`localStructYes`);
   assert.strictEqual(localStructYes.references.length, 1);
   assert.deepStrictEqual(localStructYes.references[0], {
-    range: new vscode.Range(61, 4, 61, 33),
+    range: new vscode.Range(69, 4, 69, 33),
     offset: {
       position: 0,
       length: 14
@@ -2545,10 +2553,65 @@ exports.linter38_subrefs = async () => {
   assert.strictEqual(subfe.name, `subfe`);
   assert.strictEqual(subfe.references.length, 1);
   assert.deepStrictEqual(subfe.references[0], {
-    range: new vscode.Range(62, 4, 62, 24),
+    range: new vscode.Range(70, 4, 70, 24),
     offset: {
       position: 0,
       length: 5
+    }
+  });
+
+  const qualDimStructYup = cache.find(`qualDimStructYup`);
+  assert.strictEqual(qualDimStructYup.references.length, 3)
+  
+  assert.deepStrictEqual(qualDimStructYup.references[0], {
+    range: new vscode.Range(38, 0, 38, 31),
+    offset: {
+      position: 0,
+      length: 16
+    }
+  });
+
+  assert.deepStrictEqual(qualDimStructYup.references[1], {
+    range: new vscode.Range(39, 0, 39, 45),
+    offset: {
+      position: 0,
+      length: 16
+    }
+  });
+
+  assert.deepStrictEqual(qualDimStructYup.references[2], {
+    range: new vscode.Range(40, 0, 40, 49),
+    offset: {
+      position: 0,
+      length: 16
+    }
+  });
+
+  const boopABC = qualDimStructYup.subItems[0];
+  assert.strictEqual(boopABC.name, `boopABC`);
+  assert.strictEqual(boopABC.references.length, 3);
+
+  assert.deepStrictEqual(boopABC.references[0], {
+    range: new vscode.Range(38, 0, 38, 31),
+    offset: {
+      position: 20,
+      length: 27
+    }
+  });
+
+  assert.deepStrictEqual(boopABC.references[1], {
+    range: new vscode.Range(39, 0, 39, 45),
+    offset: {
+      position: 34,
+      length: 41
+    }
+  });
+
+  assert.deepStrictEqual(boopABC.references[2], {
+    range: new vscode.Range(40, 0, 40, 49),
+    offset: {
+      position: 38,
+      length: 45
     }
   });
 }


### PR DESCRIPTION
* Adds refactoring to RPGLE language tools.
* Accounts for references that are part of qualified/dim structs

To do:

* [x] Handle when trying to rename a bad word
* [x] Skip over reference collection if a subfield (`dot` part before)
* [x] New test for reference collection against qualified/dim struct