### PR TITLE
Fixed using display file with extfile(*extdesc)

### DIFF
--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -292,6 +292,7 @@ module.exports = class Parser {
     const getObjectName = (defaultName, keywords) => {
       let objectName = defaultName;
       const extObjKeywords = [`EXTFILE`];
+      const extObjKeywordsDesc = [`EXTDESC`];
             
       // Check for external object
       extObjKeywords.forEach(keyword => {
@@ -304,6 +305,20 @@ module.exports = class Parser {
           }
         }
       });
+
+      if(objectName === `*EXTDESC`){
+        // Check for external object
+        extObjKeywordsDesc.forEach(keyword => {
+          const keywordValue = keywords.find(part => part.startsWith(`${keyword}(`) && part.endsWith(`)`));
+          if (keywordValue) {
+            objectName = keywordValue.substring(keyword.length+1, keywordValue.length - 1).toUpperCase();
+
+            if (objectName.startsWith(`'`) && objectName.endsWith(`'`)) {
+              objectName = objectName.substring(1, objectName.length - 1);
+            }
+          }
+        });
+      }
 
       return objectName;
     }


### PR DESCRIPTION
When declaring a display file with 'extfile(*extdesc)' keyword, we need to retrieve the "extdesc" keyword and value in order to retrieve the variable.
Actualy the system search for 'DISPLAY' file
`DSPFFD FILE(\*LIBL/DISPLAY) OUTPUT(\*OUTFILE) OUTFILE(ILEDITOR/RDIS934745)`
So it return a CPF3012.

### Changes

Retrieve the name's file if 'extfile' is '*extdesc' to retrieve variables.

Before :
![2022-09-23_07h44_21](https://user-images.githubusercontent.com/18192917/191898716-4daca17a-b45c-4dab-980c-4782d7661498.png)


After : 
![2022-09-23_07h46_06](https://user-images.githubusercontent.com/18192917/191898704-2f2e2d27-457e-4103-a587-72f392a72d45.png)


### Checklist

* [X] have tested my change
* [ ] updated relevant documentation
* [X] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [X] **for feature PRs**: PR only includes one feature enhancement.
