### PR TITLE
Go to definition for include and copy directive

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,12 +90,6 @@
 		},
 		"keybindings": [
 			{
-				"command": "vscode-rpgle.rpgleOpenInclude",
-				"key": "shift+f12",
-				"mac": "shift+f12",
-				"when": "editorLangId == rpgle"
-			},
-			{
 				"command": "vscode-rpgle.rpgleColumnAssistant",
 				"key": "shift+f4",
 				"mac": "shift+f4",


### PR DESCRIPTION
### Changes

This removes the open copy book shortcut (shift+f12) and implements how VS Code users expects it, with just F12. This also allows users to right click on copy/include statements to use 'Go to definition' (or peek.)

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [x] **for feature PRs**: PR only includes one feature enhancement.
