### PR TITLE
Project Mode (iteration 2)

### DIFF
--- a/client/src/builder/index.ts
+++ b/client/src/builder/index.ts
@@ -1,0 +1,110 @@
+import path = require('path');
+import { workspace } from 'vscode';
+import { LanguageClient } from 'vscode-languageclient/node';
+import { updateMakefile } from './makefile';
+
+export function initBuilder(client: LanguageClient) {
+	let substriptions = [];
+
+	if (workspace.workspaceFolders) {
+		substriptions.push(
+			workspace.onDidSaveTextDocument(async document => {
+				if (document.uri.scheme === `file` && document.languageId === `rpgle`) {
+					const uri = document.uri.toString();
+
+					const cache: any = await client.sendRequest(`getCache`, uri);
+
+					if (cache) {
+						const sourceName = path.basename(uri);
+						const detail = path.parse(uri);
+
+						// We don't do anything with include files.
+						if (detail.ext.toLowerCase() === `.rpgleinc`) return;
+
+						let deps: string[] = [];
+
+						// Build a possible object name
+						let objectName;
+						if (detail.name.toLowerCase().endsWith(`.pgm`)) {
+							objectName = path.parse(detail.name).name.toUpperCase() + `.PGM`;
+						} else {
+							objectName = detail.name + `.MODULE`;
+						}
+
+						// Then add includes
+						// NOTE: we don't add includes as deps anymore
+						// const includes: any[] = cache.includes;
+						// includes.forEach(include => {
+						// 	const sourceDep = path.basename(include.toPath);
+						// 	deps.push(sourceDep);
+						// });
+
+						// Look for file definitions
+						const files: any[] = cache.files;
+						const fileObjectSource = await Promise.all(files.map(file => {
+							const fileName = file.name.toLowerCase();
+							return workspace.findFiles(`**/{${fileName},${fileName.toUpperCase()}}.*`, undefined, 1);
+						}));
+						fileObjectSource.forEach(files => {
+							const foundFile = files[0];
+							if (foundFile) {
+								const sourceDep = path.basename(foundFile.toString());
+								deps.push(sourceDep);
+							}
+						});
+
+						// Find external data structure sources
+						const extStructs: any[] = cache.structs.filter((struct: any) => struct.keyword[`EXTNAME`]);
+						const otherFileObjectSource = await Promise.all(extStructs.map(struct => {
+							const keyword = struct.keyword;
+							const fileName = trimQuotes(keyword[`EXTNAME`]).toLowerCase();
+							return workspace.findFiles(`**/{${fileName},${fileName.toUpperCase()}}.*`, undefined, 1);
+						}));
+						otherFileObjectSource.forEach(files => {
+							const foundFile = files[0];
+							if (foundFile) {
+								const sourceDep = path.basename(foundFile.toString());
+								deps.push(sourceDep);
+							}
+						});
+
+						// Find external programs
+						const extPgms: any[] = cache.procedures.filter((proc: any) => proc.keyword[`EXTPGM`]);
+						const pgmSources = await Promise.all(extPgms.map(struct => {
+							const keyword = struct.keyword;
+							let fileName = struct.name;
+							const extpgm = keyword[`EXTPGM`];
+							if (extpgm) {
+								if (extpgm === true) fileName = struct.name;
+								else fileName = trimQuotes(extpgm);
+							}
+							return workspace.findFiles(`**/{${fileName.toLowerCase()},${fileName.toUpperCase()}}.*`, undefined, 1);
+						}));
+						pgmSources.forEach(files => {
+							const foundFile = files[0];
+							if (foundFile && foundFile.toString() !== uri) {
+								const sourceDep = path.basename(foundFile.toString());
+								deps.push(sourceDep);
+							}
+						});
+
+						deps = deps.filter(d => d !== sourceName);
+						console.log(`${sourceName}: ${deps.join(` `)}`);
+
+						if (deps.length > 0) {
+							updateMakefile(document.uri, deps);
+						}
+					}
+				}
+			})
+		);
+	}
+
+	return substriptions;
+}
+
+function trimQuotes(input: string) {
+	if (input[0] === `'`) input = input.substring(1);
+	if (input[input.length - 1] === `'`) input = input.substring(0, input.length - 1);
+	return input;
+}

--- a/client/src/builder/makefile.ts
+++ b/client/src/builder/makefile.ts
@@ -1,0 +1,51 @@
+import path = require('path');
+import { EndOfLine, RelativePattern, Uri, workspace } from 'vscode';
+
+export async function updateMakefile(baseUri: Uri, deps: string[]) {
+	const workspaceFolder = workspace.getWorkspaceFolder(baseUri);
+	const sourceName = path.basename(baseUri.path);
+	let doWrite = false;
+
+	if (workspaceFolder) {
+		const relativeFind = new RelativePattern(workspaceFolder, `**/makefile`);
+		const [makefile] = await workspace.findFiles(relativeFind, null, 1);
+
+		if (makefile) {
+			const document = await workspace.openTextDocument(makefile);
+			if (document) {
+				const eol = document.eol === EndOfLine.CRLF ? `\r\n` : `\n`;
+				let lines = document.getText().split(eol);
+
+				// This is the trigger for this functionality.
+				const startingIndex = lines.findIndex(line => line === `#DEPS`);
+
+				if (startingIndex >= 0) {
+					const existingDef = lines.findIndex(line => line.startsWith(`${sourceName}:`));
+
+					if (existingDef >= 0) {
+						const line = lines[existingDef];
+						const split = line.indexOf(`:`);
+						if (split >= 0) {
+							const existingDeps = lines[existingDef].substring(split + 1).trim().split(` `).filter(dep => dep.length);
+
+							// Remove any existing RPGLE deps. This allows users to add their custom ones still
+							const filteredDeps = existingDeps.filter(dep => !dep.toLowerCase().includes(`rpgle`) && !deps.includes(dep));
+							deps.push(...filteredDeps);
+						}
+
+						lines[existingDef] = `${sourceName}: ${deps.join(` `)}`;
+						doWrite = true;
+					} else {
+						// New file possibly? Write it as a new line
+						lines.splice(startingIndex + 1, 0, `${sourceName}: ${deps.join(` `)}`);
+						doWrite = true;
+					}
+
+					if (doWrite) {
+						await workspace.fs.writeFile(makefile, Buffer.from(lines.join(eol)));
+					}
+				}
+			}
+		}
+	}
+}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -21,6 +21,8 @@ import getBase from './base';
 
 let client: LanguageClient;
 
+const projectFilesGlob = `**/*.{rpgle,RPGLE,sqlrpgle,SQLRPGLE,rpgleinc,RPGLEINC}`;
+
 export function activate(context: ExtensionContext) {
 	// The server is implemented in node
 	const serverModule = context.asAbsolutePath(
@@ -51,7 +53,7 @@ export function activate(context: ExtensionContext) {
 			// Notify the server about file changes to '.clientrc files contained in the workspace
 			fileEvents: [
 				workspace.createFileSystemWatcher('**/rpglint.json'),
-				workspace.createFileSystemWatcher(`**/*.{rpgle,RPGLE,sqlrpgle,SQLRPGLE,rpgleinc,RPGLEINC}`),
+				workspace.createFileSystemWatcher(projectFilesGlob),
 			]
 		}
 	};
@@ -99,6 +101,15 @@ export function activate(context: ExtensionContext) {
 
 			return;
 		});
+
+		client.onRequest(`getProjectFiles`, async (): Promise<string[]|undefined> => {
+			if (workspace.workspaceFolders) {
+				const uris = await workspace.findFiles(projectFilesGlob);
+				return uris.map(uri => uri.toString());
+			}
+
+			return undefined;
+		})
 
 		client.onRequest(`getObject`, async (table: string) => {
 			const instance = getBase();

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 
 import * as path from 'path';
-import { workspace, ExtensionContext, Uri, commands } from 'vscode';
+import { workspace, ExtensionContext, Uri, commands, RelativePattern } from 'vscode';
 
 import * as Linter from "./linter";
 import * as columnAssist from "./columnAssist";
@@ -68,7 +68,7 @@ export function activate(context: ExtensionContext) {
 	);
 
 	client.onReady().then(() => {
-		client.onRequest("getUri", async (stringUri: string): Promise<string|undefined> => {
+		client.onRequest("getUri", async (stringUri: string): Promise<string | undefined> => {
 			const uri = Uri.parse(stringUri);
 			let doc;
 			try {
@@ -80,18 +80,18 @@ export function activate(context: ExtensionContext) {
 			if (doc) {
 				return doc.uri.toString();
 			} else
-			if (uri.scheme === `file`) {
-				const basename = path.basename(uri.path);
-				const [possibleFile] = await workspace.findFiles(`**/${basename}`, undefined, 1);
-				if (possibleFile) {
-					return possibleFile.toString();
+				if (uri.scheme === `file`) {
+					const basename = path.basename(uri.path);
+					const [possibleFile] = await workspace.findFiles(`**/${basename}`, undefined, 1);
+					if (possibleFile) {
+						return possibleFile.toString();
+					}
 				}
-			}
 
 			return;
 		});
 
-		client.onRequest("getFile", async (stringUri: string) : Promise<string|undefined> => { 
+		client.onRequest("getFile", async (stringUri: string): Promise<string | undefined> => {
 			// Always assumes URI is valid. Use getUri first
 			const uri = Uri.parse(stringUri);
 			const doc = await workspace.openTextDocument(uri);
@@ -103,13 +103,34 @@ export function activate(context: ExtensionContext) {
 			return;
 		});
 
-		client.onRequest(`getProjectFiles`, async (): Promise<string[]|undefined> => {
+		client.onRequest(`getProjectFiles`, async (): Promise<string[] | undefined> => {
 			if (workspace.workspaceFolders) {
 				const uris = await workspace.findFiles(projectFilesGlob);
 				return uris.map(uri => uri.toString());
 			}
 
 			return undefined;
+		});
+
+		client.onRequest(`getIncludesUris`, async (stringUri: string): Promise<{uri: string, relative: string}[]> => {
+			if (workspace.workspaceFolders) {
+				const uri = Uri.parse(stringUri);
+				const workspaceFolder = workspace.getWorkspaceFolder(uri);
+
+				if (workspaceFolder) {
+					const relativeWorkspace = new RelativePattern(workspaceFolder, `**/*.{rpgleinc,RPGLEINC}`);
+					const localFiles = await workspace.findFiles(relativeWorkspace);
+
+					return localFiles.map(localFile => {
+						return {
+							uri: localFile.toString(),
+							relative: path.relative(workspaceFolder.uri.path, localFile.path)
+						};
+					});
+				}
+			}
+
+			return [];
 		});
 
 		client.onRequest(`getObject`, async (table: string) => {
@@ -120,7 +141,7 @@ export function activate(context: ExtensionContext) {
 				if (connection) {
 					const content = instance.getContent();
 					const config = instance.getConfig();
-		
+
 					const dateStr = Date.now().toString().substr(-6);
 					const randomFile = `R${table.substring(0, 3)}${dateStr}`.substring(0, 10);
 					const fullPath = `${config.tempLibrary}/${randomFile}`;
@@ -131,7 +152,7 @@ export function activate(context: ExtensionContext) {
 						schema: `*LIBL`,
 						table: ``,
 					};
-		
+
 					if (table.includes(`/`)) {
 						const splitName = table.split(`/`);
 						if (splitName.length >= 2) parts.schema = splitName[splitName.length - 2];
@@ -169,7 +190,7 @@ export function activate(context: ExtensionContext) {
 	columnAssist.registerColumnAssist(context);
 
 	// context.subscriptions.push(...initBuilder(client));
-	
+
 	console.log(`started`);
 }
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -49,7 +49,10 @@ export function activate(context: ExtensionContext) {
 		],
 		synchronize: {
 			// Notify the server about file changes to '.clientrc files contained in the workspace
-			fileEvents: workspace.createFileSystemWatcher('**/rpglint.json'),
+			fileEvents: [
+				workspace.createFileSystemWatcher('**/rpglint.json'),
+				workspace.createFileSystemWatcher(`**/*.{rpgle,RPGLE,sqlrpgle,SQLRPGLE,rpgleinc,RPGLEINC}`),
+			]
 		}
 	};
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -18,6 +18,7 @@ import {
 } from 'vscode-languageclient/node';
 
 import getBase from './base';
+import { initBuilder } from './builder';
 
 let client: LanguageClient;
 
@@ -166,6 +167,8 @@ export function activate(context: ExtensionContext) {
 
 	Linter.initialise(context);
 	columnAssist.registerColumnAssist(context);
+
+	// context.subscriptions.push(...initBuilder(client));
 	
 	console.log(`started`);
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -109,7 +109,7 @@ export function activate(context: ExtensionContext) {
 			}
 
 			return undefined;
-		})
+		});
 
 		client.onRequest(`getObject`, async (table: string) => {
 			const instance = getBase();

--- a/server/src/connection.ts
+++ b/server/src/connection.ts
@@ -48,3 +48,7 @@ export async function getFileRequest(uri: string) {
 export function getObject(objectPath: string): Promise<object[]> {
 	return connection.sendRequest("getObject", objectPath);
 }
+
+export function getProjectFiles(): Promise<string[]|undefined> {
+	return connection.sendRequest("getProjectFiles");
+}

--- a/server/src/connection.ts
+++ b/server/src/connection.ts
@@ -1,5 +1,7 @@
+import { connect } from 'http2';
 import {
 	createConnection,
+	DidChangeWatchedFilesParams,
 	ProposedFeatures,
 	_Connection
 } from 'vscode-languageserver/node';
@@ -10,6 +12,11 @@ import { documents, findFile } from './providers';
 // Create a connection for the server, using Node's IPC as a transport.
 // Also include all preview / proposed LSP features.
 export const connection: _Connection = createConnection(ProposedFeatures.all);
+
+export let watchedFilesChangeEvent: ((params: DidChangeWatchedFilesParams) => void)[] = [];
+connection.onDidChangeWatchedFiles((params: DidChangeWatchedFilesParams) => {
+	watchedFilesChangeEvent.forEach(editEvent => editEvent(params));
+})
 
 export async function validateUri(stringUri: string, scheme = ``) {
 	// First, check local cache

--- a/server/src/connection.ts
+++ b/server/src/connection.ts
@@ -52,3 +52,7 @@ export function getObject(objectPath: string): Promise<object[]> {
 export function getProjectFiles(): Promise<string[]|undefined> {
 	return connection.sendRequest("getProjectFiles");
 }
+
+export function getIncludesUris(uri: string): Promise<{uri: string, relative: string}[]> {
+	return connection.sendRequest(`getIncludesUris`, uri);
+}

--- a/server/src/providers/completionItem.ts
+++ b/server/src/providers/completionItem.ts
@@ -1,10 +1,13 @@
+import path = require('path');
 import { CompletionItem, CompletionItemKind, CompletionParams, Position, Range } from 'vscode-languageserver';
 import { documents, getWordRangeAtPosition, parser } from '.';
+import { getIncludesUris } from '../connection';
 import Cache from '../language/models/cache';
 import Declaration from '../language/models/declaration';
+import * as Project from "./project";
 
 export default async function completionItemProvider(handler: CompletionParams): Promise<CompletionItem[]> {
-	const items: CompletionItem[] =[];
+	const items: CompletionItem[] = [];
 	const lineNumber = handler.position.line;
 
 	const trigger = handler.context?.triggerCharacter;
@@ -72,43 +75,78 @@ export default async function completionItemProvider(handler: CompletionParams):
 			} else {
 				// Normal defines and all that.....
 				// TODO: handle /COPY and /INCLUDE
+				const upperLine = currentLine.toUpperCase();
+				if (Project.isEnabled && (upperLine.includes(`/COPY`) || upperLine.includes(`/INCLUDE`))) {
+					const localFiles = await getIncludesUris(currentPath);
 
-				const expandScope = (localCache: Cache) => {
-					for (const procedure of localCache.procedures) {
-						const item = CompletionItem.create(`${procedure.name}`);
-						item.kind = CompletionItemKind.Function;
-						item.insertText = `${procedure.name}(${procedure.subItems.map((parm, index) => `\${${index + 1}:${parm.name}}`).join(`:`)})`;
-						item.detail = procedure.keywords.join(` `);
-						item.documentation = procedure.description;
-						items.push(item);
-					}
+					items.push(...localFiles.map(file => {
+						const basename = path.basename(file.uri);
 
-					for (const subroutine of localCache.subroutines) {
-						const item = CompletionItem.create(`${subroutine.name}`);
-						item.kind = CompletionItemKind.Function;
-						item.insertText = `${subroutine.name}`;
-						item.documentation = subroutine.description;
-						items.push(item);
-					}
-
-					for (const variable of localCache.variables) {
-						const item = CompletionItem.create(`${variable.name}`);
-						item.kind = CompletionItemKind.Variable;
-						item.insertText = `${variable.name}`;
-						item.detail = variable.keywords.join(` `);
-						item.documentation = variable.description;
-						items.push(item);
-					}
-
-					localCache.files.forEach(file => {
-						const item = CompletionItem.create(`${file.name}`);
+						const item = CompletionItem.create(basename);
 						item.kind = CompletionItemKind.File;
-						item.insertText = `${file.name}`;
-						item.detail = file.keywords.join(` `);
-						item.documentation = file.description;
-						items.push(item);
+						item.insertText = `'${file.relative}'`;
+						item.detail = file.relative;
+						return item;
+					}));
+					
+				} else {
+					const expandScope = (localCache: Cache) => {
+						for (const procedure of localCache.procedures) {
+							const item = CompletionItem.create(`${procedure.name}`);
+							item.kind = CompletionItemKind.Function;
+							item.insertText = `${procedure.name}(${procedure.subItems.map((parm, index) => `\${${index + 1}:${parm.name}}`).join(`:`)})`;
+							item.detail = procedure.keywords.join(` `);
+							item.documentation = procedure.description;
+							items.push(item);
+						}
 
-						for (const struct of file.subItems) {
+						for (const subroutine of localCache.subroutines) {
+							const item = CompletionItem.create(`${subroutine.name}`);
+							item.kind = CompletionItemKind.Function;
+							item.insertText = `${subroutine.name}`;
+							item.documentation = subroutine.description;
+							items.push(item);
+						}
+
+						for (const variable of localCache.variables) {
+							const item = CompletionItem.create(`${variable.name}`);
+							item.kind = CompletionItemKind.Variable;
+							item.insertText = `${variable.name}`;
+							item.detail = variable.keywords.join(` `);
+							item.documentation = variable.description;
+							items.push(item);
+						}
+
+						localCache.files.forEach(file => {
+							const item = CompletionItem.create(`${file.name}`);
+							item.kind = CompletionItemKind.File;
+							item.insertText = `${file.name}`;
+							item.detail = file.keywords.join(` `);
+							item.documentation = file.description;
+							items.push(item);
+
+							for (const struct of file.subItems) {
+								const item = CompletionItem.create(`${struct.name}`);
+								item.kind = CompletionItemKind.Struct;
+								item.insertText = `${struct.name}`;
+								item.detail = struct.keywords.join(` `);
+								item.documentation = struct.description;
+								items.push(item);
+
+								if (!struct.keyword[`QUALIFIED`]) {
+									struct.subItems.forEach((subItem: Declaration) => {
+										const item = CompletionItem.create(`${subItem.name}`);
+										item.kind = CompletionItemKind.Property;
+										item.insertText = `${subItem.name}`;
+										item.detail = subItem.keywords.join(` `);
+										item.documentation = subItem.description + ` (${struct.name})`;
+										items.push(item);
+									});
+								}
+							}
+						});
+
+						for (const struct of localCache.structs) {
 							const item = CompletionItem.create(`${struct.name}`);
 							item.kind = CompletionItemKind.Struct;
 							item.insertText = `${struct.name}`;
@@ -127,52 +165,32 @@ export default async function completionItemProvider(handler: CompletionParams):
 								});
 							}
 						}
-					});
 
-					for (const struct of localCache.structs) {
-						const item = CompletionItem.create(`${struct.name}`);
-						item.kind = CompletionItemKind.Struct;
-						item.insertText = `${struct.name}`;
-						item.detail = struct.keywords.join(` `);
-						item.documentation = struct.description;
-						items.push(item);
-
-						if (!struct.keyword[`QUALIFIED`]) {
-							struct.subItems.forEach((subItem: Declaration) => {
-								const item = CompletionItem.create(`${subItem.name}`);
-								item.kind = CompletionItemKind.Property;
-								item.insertText = `${subItem.name}`;
-								item.detail = subItem.keywords.join(` `);
-								item.documentation = subItem.description + ` (${struct.name})`;
-								items.push(item);
-							});
+						for (const constant of localCache.constants) {
+							const item = CompletionItem.create(`${constant.name}`);
+							item.kind = CompletionItemKind.Constant;
+							item.insertText = `${constant.name}`;
+							item.detail = constant.keywords.join(` `);
+							item.documentation = constant.description;
+							items.push(item);
 						}
-					}
+					};
 
-					for (const constant of localCache.constants) {
-						const item = CompletionItem.create(`${constant.name}`);
-						item.kind = CompletionItemKind.Constant;
-						item.insertText = `${constant.name}`;
-						item.detail = constant.keywords.join(` `);
-						item.documentation = constant.description;
-						items.push(item);
-					}
-				};
+					expandScope(doc);
 
-				expandScope(doc);
+					if (currentProcedure) {
+						for (const subItem of currentProcedure.subItems) {
+							const item = CompletionItem.create(`${subItem.name}`);
+							item.kind = CompletionItemKind.Variable;
+							item.insertText = subItem.name;
+							item.detail = [`parameter`, ...subItem.keywords].join(` `);
+							item.documentation = subItem.description;
+							items.push(item);
+						}
 
-				if (currentProcedure) {
-					for (const subItem of currentProcedure.subItems) {
-						const item = CompletionItem.create(`${subItem.name}`);
-						item.kind = CompletionItemKind.Variable;
-						item.insertText = subItem.name;
-						item.detail = [`parameter`, ...subItem.keywords].join(` `);
-						item.documentation = subItem.description;
-						items.push(item);
-					}
-
-					if (currentProcedure.scope) {
-						expandScope(currentProcedure.scope);
+						if (currentProcedure.scope) {
+							expandScope(currentProcedure.scope);
+						}
 					}
 				}
 			}

--- a/server/src/providers/linter/index.ts
+++ b/server/src/providers/linter/index.ts
@@ -4,7 +4,7 @@ import { CodeAction, CodeActionKind, Diagnostic, DiagnosticSeverity, DidChangeWa
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
 import { documents, parser } from '..';
-import { connection, getFileRequest, validateUri } from '../../connection';
+import { connection, getFileRequest, validateUri, watchedFilesChangeEvent } from '../../connection';
 import { IssueRange } from '../../language/index';
 import Linter from '../../language/linter';
 import Cache from '../../language/models/cache';
@@ -17,7 +17,7 @@ export function initialise(connection: _Connection) {
 	connection.onCodeAction(codeActionsProvider);
 	connection.onDocumentFormatting(documentFormattingProvider);
 
-	connection.onDidChangeWatchedFiles((params: DidChangeWatchedFilesParams) => {
+	watchedFilesChangeEvent.push((params: DidChangeWatchedFilesParams) => {
 		let runLinter = false;
 
 		params.changes.forEach(file => {

--- a/server/src/providers/project/implementation.ts
+++ b/server/src/providers/project/implementation.ts
@@ -1,0 +1,41 @@
+import { Definition, ImplementationParams, Location, Range } from 'vscode-languageserver';
+import { documents, parser, getWordRangeAtPosition } from '..';
+
+import * as Project from '.';
+
+export default function implementationProvider(params: ImplementationParams): Definition | undefined {
+	if (Project.isEnabled) {
+		const currentPath = params.textDocument.uri;
+		const document = documents.get(currentPath);
+
+		if (document) {
+			const word = getWordRangeAtPosition(document, params.position);
+			if (word) {
+				const upperName = word.toUpperCase();
+				const parsedFiles = Object.keys(parser.parsedCache);
+
+				for (const uri of parsedFiles) {
+					const cache = parser.getParsedCache(uri);
+					for (const proc of cache.procedures) {
+						const keyword = proc.keyword[`EXPORT`];
+						if (keyword) {
+							if (proc.name.toUpperCase() === upperName) {
+								return Location.create(
+									proc.position.path,
+									Range.create(
+										proc.position.line,
+										0,
+										proc.position.line,
+										0
+									)
+								);
+							}
+						}
+					}
+				};
+			}
+		}
+	}
+
+	return;
+}

--- a/server/src/providers/project/index.ts
+++ b/server/src/providers/project/index.ts
@@ -72,33 +72,25 @@ export function findAllReferences(def: Declaration): Location[] {
 			if (document) {
 				const cache = parser.getParsedCache(uri);
 
-				// If this cache include a copybook
+				// It's only a valid reference if it is imported somewhere else
 				const foundInclude = cache.includes.find(include => include.toPath === baseUri)
 				if (foundInclude) {
 					const possibleDef = cache.find(def.name);
 
 					// Okay, we found something with a similar name in another file...
 					if (possibleDef) {
-						if (def.type === `procedure`) {
-							// If it's a procedure definition, check it's got EXTPROC on it
-							if (possibleDef.type === `procedure` && possibleDef.keyword[`EXTPROC`]) {
+						if (possibleDef.position.path === def.position.path) {
+							locations.push(
+								// First, we push the copybook where it is brought in.
+								// We do this because we don't have references for non-**free
+								Location.create(uri, Range.create(foundInclude.line, 0, foundInclude.line, 0)),
 
-							}
-
-						} else {
-							if (possibleDef.position.path === def.position.path) {
-								locations.push(
-									// First, we push the copybook where it is brought in.
-									// We do this because we don't have references for non-**free
-									Location.create(uri, Range.create(foundInclude.line, 0, foundInclude.line, 0)),
-
-									// Then we push the references. Empty for non-**free
-									...possibleDef.references.map(ref => Location.create(
-										uri,
-										calculateOffset(document, ref)
-									))
-								);
-							}
+								// Then we push the references. Empty for non-**free
+								...possibleDef.references.map(ref => Location.create(
+									uri,
+									calculateOffset(document, ref)
+								))
+							);
 						}
 					}
 				}

--- a/server/src/providers/project/index.ts
+++ b/server/src/providers/project/index.ts
@@ -1,4 +1,4 @@
-import { getFileRequest, getProjectFiles, watchedFilesChangeEvent } from '../../connection';
+import { connection, getFileRequest, getProjectFiles, watchedFilesChangeEvent } from '../../connection';
 import { documents, parser } from '..';
 import Linter from '../../language/linter';
 import Cache from '../../language/models/cache';
@@ -28,6 +28,10 @@ export async function initialise() {
 					break;
 			}
 		})
+	});
+
+	connection.onRequest(`getCache`, (uri: string) => {
+		return parser.getParsedCache(uri);
 	});
 }
 

--- a/server/src/providers/project/index.ts
+++ b/server/src/providers/project/index.ts
@@ -22,7 +22,7 @@ export async function initialise() {
 				case FileChangeType.Changed:
 					loadFile(fileEvent.uri);
 					break;
-					
+
 				default:
 					parser.clearParsedCache(fileEvent.uri);
 					break;
@@ -62,41 +62,113 @@ async function loadFile(uri: string) {
 export function findAllReferences(def: Declaration): Location[] {
 	let locations: Location[] = [];
 
+	const parsedFiles = Object.keys(parser.parsedCache);
+
+	const document = documents.get(def.position.path);
+
+	if (document) {
+		locations.push(
+			...def.references.map(ref => Location.create(
+				def.position.path,
+				calculateOffset(document, ref)
+			))
+		);
+	}
+
 	if (isEnabled) {
-		const baseUri = def.position.path;
+		if (def.keyword[`EXPORT`]) {
+			// If we are looking for references to an export function
+			// scan entire project for `EXTPROC` definitions that point to this
+			const upperName = def.name.toUpperCase();
 
-		const parsedCache = Object.keys(parser.parsedCache);
+			for (const keyPath of parsedFiles) {
+				const document = documents.get(keyPath);
 
-		parsedCache.forEach(uri => {
-			const document = documents.get(uri);
-			if (document) {
-				const cache = parser.getParsedCache(uri);
+				if (document) {
+					const cache = parser.getParsedCache(keyPath);
 
-				// It's only a valid reference if it is imported somewhere else
-				const foundInclude = cache.includes.find(include => include.toPath === baseUri)
-				if (foundInclude) {
-					const possibleDef = cache.find(def.name);
+					cache.procedures.forEach(proc => {
+						let addReference = false;
+						const keyword = proc.keyword[`EXTPROC`];
+						if (keyword) {
+							if (keyword === true) {
+								if (proc.name.toUpperCase() === upperName) {
 
-					// Okay, we found something with a similar name in another file...
-					if (possibleDef) {
-						if (possibleDef.position.path === def.position.path) {
-							locations.push(
-								// First, we push the copybook where it is brought in.
-								// We do this because we don't have references for non-**free
-								Location.create(uri, Range.create(foundInclude.line, 0, foundInclude.line, 0)),
+									addReference = true;
+								}
+							} else
+								if (trimQuotes(keyword).toUpperCase() === upperName) {
+									addReference = true;
+								}
+						} else
 
-								// Then we push the references. Empty for non-**free
-								...possibleDef.references.map(ref => Location.create(
-									uri,
-									calculateOffset(document, ref)
-								))
-							);
+							// Also turns out, any `DCL-PR` without any keywords is `EXTPROC` by default.
+							if (!proc.keyword[`EXPORT`] && proc.name.toUpperCase() === upperName) {
+								addReference = true;
+							}
+
+						if (addReference) {
+							// Don't add duplicates
+							if (!locations.some(loc => loc.uri === keyPath)) {
+								locations.push(
+									// First, we push the copybook where it is brought in.
+									// We do this because we don't have references for non-**free
+									Location.create(proc.position.path, Range.create(proc.position.line, 0, proc.position.line, 0)),
+
+									// Then we push the references. Empty for non-**free
+									...proc.references.map(ref => Location.create(
+										keyPath,
+										calculateOffset(document, ref)
+									))
+								);
+							}
+						}
+
+					})
+				}
+			}
+
+		} else {
+			// Otherwise, we are looking for references to the current definition
+			const baseUri = def.position.path;
+
+			parsedFiles.forEach(uri => {
+				const document = documents.get(uri);
+				if (document) {
+					const cache = parser.getParsedCache(uri);
+
+					// It's only a valid reference if it is imported somewhere else
+					const foundInclude = cache.includes.find(include => include.toPath === baseUri)
+					if (foundInclude) {
+						const possibleDef = cache.find(def.name);
+
+						// Okay, we found something with a similar name in another file...
+						if (possibleDef) {
+							if (possibleDef.position.path === def.position.path) {
+								locations.push(
+									// First, we push the copybook where it is brought in.
+									// We do this because we don't have references for non-**free
+									Location.create(uri, Range.create(foundInclude.line, 0, foundInclude.line, 0)),
+
+									// Then we push the references. Empty for non-**free
+									...possibleDef.references.map(ref => Location.create(
+										uri,
+										calculateOffset(document, ref)
+									))
+								);
+							}
 						}
 					}
 				}
-			}
-		})
+			})
+		}
 	}
 
 	return locations;
+}
+
+function trimQuotes(input: string) {
+	if (input[0] === `'`) input = input.substring(1);
+	if (input[input.length - 1] === `'`) input = input.substring(0, input.length - 1);
+	return input;
 }

--- a/server/src/providers/project/index.ts
+++ b/server/src/providers/project/index.ts
@@ -1,0 +1,58 @@
+import { getFileRequest, getProjectFiles, watchedFilesChangeEvent } from '../../connection';
+import { parser } from '..';
+import Linter from '../../language/linter';
+import Cache from '../../language/models/cache';
+import { DidChangeWatchedFilesParams, FileChangeType } from 'vscode-languageserver';
+
+export let isEnabled = false;
+/**
+ * Assumes client has workspace
+ */
+export async function initialise() {
+	isEnabled = true;
+
+	loadWorkspace();
+
+	watchedFilesChangeEvent.push((params: DidChangeWatchedFilesParams) => {
+		params.changes.forEach(fileEvent => {
+			switch (fileEvent.type) {
+				case FileChangeType.Created:
+				case FileChangeType.Changed:
+					loadFile(fileEvent.uri);
+					break;
+					
+				default:
+					parser.clearParsedCache(fileEvent.uri);
+					break;
+			}
+		})
+	});
+}
+
+async function loadWorkspace() {
+	const uris = await getProjectFiles();
+
+	if (uris) {
+		const documents = await Promise.allSettled(uris?.map(uri => loadFile(uri)));
+	}
+}
+
+async function loadFile(uri: string) {
+	const content = await getFileRequest(uri);
+
+	if (content) {
+		parser.getDocs(uri, content).then(cache => {
+			// Linter / reference collector only works on free-format.
+			if (cache) {
+				if (content.length >= 6 && content.substring(0, 6).toUpperCase() === `**FREE`) {
+					Linter.getErrors({
+						uri,
+						content,
+					}, {
+						CollectReferences: true
+					}, cache);
+				}
+			}
+		});
+	}
+}

--- a/server/src/providers/project/workspaceSymbol.ts
+++ b/server/src/providers/project/workspaceSymbol.ts
@@ -1,0 +1,57 @@
+import { Range, SymbolKind, WorkspaceSymbol, WorkspaceSymbolParams } from 'vscode-languageserver';
+import {parser} from '..';
+import * as Project from '.';
+import path = require('path');
+
+export default function workspaceSymbolProvider(params: WorkspaceSymbolParams): WorkspaceSymbol[]|undefined {
+	console.log(params.query);
+	if (Project.isEnabled) {
+		const parsedFiles = Object.keys(parser.parsedCache);
+		let symbols: WorkspaceSymbol[] = [];
+
+		parsedFiles.forEach(uri => {
+			const basename = path.basename(uri);
+
+			if (uri.endsWith(`.rpgleinc`)) {
+				symbols.push(
+					WorkspaceSymbol.create(
+						basename,
+						SymbolKind.File,
+						uri,
+						Range.create(
+							0,
+							0,
+							0,
+							0
+						)
+					)
+				)
+
+			} else {
+				const cache = parser.getParsedCache(uri);
+
+				cache.procedures.forEach(proc => {
+					if (proc.keyword[`EXPORT`]) {
+						symbols.push(
+							WorkspaceSymbol.create(
+								proc.name,
+								SymbolKind.Function,
+								uri,
+								Range.create(
+									proc.position.line,
+									0,
+									proc.position.line,
+									0
+								)
+							)
+						);
+					}
+				});
+			}
+		});
+
+		return symbols;
+	}
+
+	return;
+}

--- a/server/src/providers/reference.ts
+++ b/server/src/providers/reference.ts
@@ -3,6 +3,8 @@ import { documents, getWordRangeAtPosition, parser } from '.';
 import Linter from '../language/linter';
 import { calculateOffset } from './linter';
 
+import * as Project from "./project";
+
 export async function referenceProvider(params: ReferenceParams): Promise<Location[]|undefined> {
 	const uri = params.textDocument.uri;
 	const position = params.position;
@@ -11,14 +13,13 @@ export async function referenceProvider(params: ReferenceParams): Promise<Locati
 	if (document) {
 		const isFree = (document.getText(Range.create(0, 0, 0, 6)).toUpperCase() === `**FREE`);
 
-		if (isFree) {
-			let locations: Location[] = [];
-			const word = getWordRangeAtPosition(document, position);
+		const word = getWordRangeAtPosition(document, position);
 
-			if (word) {
-				const doc = await parser.getDocs(uri, document.getText());
+		if (word) {
+			const doc = await parser.getDocs(uri, document.getText());
 
-				if (doc) {
+			if (doc) {
+				if (isFree) {
 					Linter.getErrors(
 						{
 							uri,
@@ -29,14 +30,18 @@ export async function referenceProvider(params: ReferenceParams): Promise<Locati
 						},
 						doc
 					);
+				}
 
-					const def = doc.findDefinition(position.line, word);
+				const def = doc.findDefinition(position.line, word);
 
-					if (def) {
+				if (def) {
+					if (Project.isEnabled) {
+						return Project.findAllReferences(def);
+					} else {
 						return def.references.map(ref => Location.create(
 							def.position.path,
 							calculateOffset(document, ref)
-						));
+						));	
 					}
 				}
 			}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -96,6 +96,8 @@ connection.onInitialize((params: InitializeParams) => {
 		}
 	}
 
+	console.log(`Project Mode enabled: ${projectEnabled}`);
+
 	return result;
 });
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -24,6 +24,7 @@ import { getPrettyType } from './language/models/fixed';
 
 import * as Project from './providers/project';
 import workspaceSymbolProvider from './providers/project/workspaceSymbol';
+import implementationProvider from './providers/project/implementation';
 
 let hasConfigurationCapability = false;
 let hasWorkspaceFolderCapability = false;
@@ -91,6 +92,7 @@ connection.onInitialize((params: InitializeParams) => {
 		if (workspaceFolders && workspaceFolders.length > 0) {
 			projectEnabled = true;
 			result.capabilities.workspaceSymbolProvider = true;
+			result.capabilities.implementationProvider = true;
 		}
 	}
 
@@ -220,7 +222,10 @@ if (languageToolsEnabled) {
 	connection.onCompletion(completionItemProvider);
 	connection.onHover(hoverProvider);
 	connection.onReferences(referenceProvider);
+
+	// project specific
 	connection.onWorkspaceSymbol(workspaceSymbolProvider);
+	connection.onImplementation(implementationProvider)
 }
 
 if (linterEnabled) Linter.initialise(connection);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -22,6 +22,8 @@ import { referenceProvider } from './providers/reference';
 import Declaration from './language/models/declaration';
 import { getPrettyType } from './language/models/fixed';
 
+import * as Project from './providers/project';
+
 let hasConfigurationCapability = false;
 let hasWorkspaceFolderCapability = false;
 let hasDiagnosticRelatedInformationCapability = false;
@@ -79,6 +81,15 @@ connection.onInitialize((params: InitializeParams) => {
 			},
 		};
 	}
+
+	if (languageToolsEnabled && hasWorkspaceFolderCapability) {
+		const workspaceFolders = params.workspaceFolders;
+
+		if (workspaceFolders && workspaceFolders.length > 0) {
+			Project.initialise();
+		}
+	}
+
 	return result;
 });
 
@@ -213,7 +224,7 @@ documents.onDidChangeContent(handler => {
 			ignoreCache: true
 		}
 	).then(cache => {
-		if (linterEnabled && cache) {
+		if (cache) {
 			Linter.refreshDiagnostics(handler.document, cache);
 		}
 	});


### PR DESCRIPTION
### Changes

This changes are to enhance local development. While the content assist will continue to work for source members, this adds extended support for local since we know about the entire project.

* Completion provider
   * Support for prompting paths to local include files (`.rpgleinc`)
* Find references
   * Find references from includes will show: where the include is used and where the references are (if it's free format)
   * Find references from export functions: will show all `extproc` definitions are and references are (if it's free format)
* Go to implementation
   * Will go to where the `export` function is defined
* Global reference provider
   * Search all export procedures and `.rpgleinc` files

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
