### PR TITLE
Validate local paths

### DIFF
--- a/server/src/connection.ts
+++ b/server/src/connection.ts
@@ -53,6 +53,11 @@ export function getProjectFiles(): Promise<string[]|undefined> {
 	return connection.sendRequest("getProjectFiles");
 }
 
-export function getIncludesUris(uri: string): Promise<{uri: string, relative: string}[]> {
+export interface PossibleInclude {
+	uri: string;
+	relative: string
+};
+
+export function getIncludesUris(uri: string): Promise<PossibleInclude[]> {
 	return connection.sendRequest(`getIncludesUris`, uri);
 }

--- a/server/src/language/linter.js
+++ b/server/src/language/linter.js
@@ -288,6 +288,9 @@ export default class Linter {
                           if (path.type === `word`) {
                             // /INCLUDE MEMBER
                             // This is bad.
+                            const pathValue = path.value.substring(1, path.value.length - 1).trim().toUpperCase();
+                            const possibleValue = (data.availableIncludes && data.availableIncludes.length > 0) ? data.availableIncludes.find(cPathValue => cPathValue.toUpperCase().includes(pathValue.toUpperCase())) : undefined;
+
                             errors.push({
                               range: new Range(
                                 statementStart,
@@ -295,10 +298,12 @@ export default class Linter {
                               ),
                               offset: {position: path.position, end: path.position + path.value.length},
                               type: `IncludeMustBeRelative`,
+                              newValue: possibleValue ? `'${possibleValue}'` : undefined
                             });
                           } else if (path.type === `string`) {
                             // /INCLUDE 'path/to/file'
                             const pathValue = path.value.substring(1, path.value.length - 1).trim();
+
                             if (pathValue.startsWith(`/`) === true) {
                               // Bad. Path must not be absolute.
                               errors.push({
@@ -307,14 +312,14 @@ export default class Linter {
                                   statementEnd
                                 ),
                                 offset: {position: path.position, end: path.position + path.value.length},
-                                type: `IncludeMustBeRelative`,
+                                type: `IncludeMustBeRelative`
                               });
                             } else
                             if (data.availableIncludes && data.availableIncludes.length > 0) {
-                              const correctValue = data.availableIncludes.find(cPathValue => cPathValue.toUpperCase().includes(pathValue.toUpperCase()));
-                              if (correctValue) {
+                              const possibleValue = data.availableIncludes.find(cPathValue => cPathValue.toUpperCase().includes(pathValue.toUpperCase()));
+                              if (possibleValue) {
                                 // This means there was a possible match
-                                if (pathValue !== correctValue) {
+                                if (pathValue !== possibleValue) {
                                   // But if they're not the same, offer a fix
                                   errors.push({
                                     range: new Range(
@@ -323,7 +328,7 @@ export default class Linter {
                                     ),
                                     offset: {position: path.position, end: path.position + path.value.length},
                                     type: `IncludeMustBeRelative`,
-                                    newValue: `'${correctValue}'`
+                                    newValue: `'${possibleValue}'`
                                   });
                                 }
                               }

--- a/server/src/language/linter.js
+++ b/server/src/language/linter.js
@@ -44,7 +44,7 @@ export default class Linter {
   }
 
   /**
-   * @param {{uri: string, content: string}} data
+   * @param {{uri: string, content: string, availableIncludes?: string[]}} data
    * @param {Rules} rules 
    * @param {Cache|null} [globalScope]
    */
@@ -309,6 +309,25 @@ export default class Linter {
                                 offset: {position: path.position, end: path.position + path.value.length},
                                 type: `IncludeMustBeRelative`,
                               });
+                            } else
+                            if (data.availableIncludes && data.availableIncludes.length > 0) {
+                              const correctValue = data.availableIncludes.find(cPathValue => cPathValue.toUpperCase().includes(pathValue.toUpperCase()));
+                              if (correctValue) {
+                                // This means there was a possible match
+                                if (pathValue !== correctValue) {
+                                  // But if they're not the same, offer a fix
+                                  errors.push({
+                                    range: new Range(
+                                      statementStart,
+                                      statementEnd
+                                    ),
+                                    offset: {position: path.position, end: path.position + path.value.length},
+                                    type: `IncludeMustBeRelative`,
+                                    newValue: `'${correctValue}'`
+                                  });
+                                }
+                              }
+                              // If there's no match, we can't complain incase they're using incdir or something...
                             }
                           }
                         } else {

--- a/server/src/providers/completionItem.ts
+++ b/server/src/providers/completionItem.ts
@@ -1,7 +1,6 @@
 import path = require('path');
 import { CompletionItem, CompletionItemKind, CompletionParams, InsertTextFormat, Position, Range } from 'vscode-languageserver';
 import { documents, getWordRangeAtPosition, parser } from '.';
-import { getIncludesUris } from '../connection';
 import Cache from '../language/models/cache';
 import Declaration from '../language/models/declaration';
 import * as Project from "./project";
@@ -77,7 +76,7 @@ export default async function completionItemProvider(handler: CompletionParams):
 				// TODO: handle /COPY and /INCLUDE
 				const upperLine = currentLine.toUpperCase();
 				if (Project.isEnabled && (upperLine.includes(`/COPY`) || upperLine.includes(`/INCLUDE`))) {
-					const localFiles = await getIncludesUris(currentPath);
+					const localFiles = await Project.getIncludes(currentPath);
 
 					items.push(...localFiles.map(file => {
 						const basename = path.basename(file.uri);

--- a/server/src/providers/project/index.ts
+++ b/server/src/providers/project/index.ts
@@ -1,4 +1,4 @@
-import { connection, getFileRequest, getProjectFiles, watchedFilesChangeEvent } from '../../connection';
+import { connection, getFileRequest, getIncludesUris, getProjectFiles, PossibleInclude, watchedFilesChangeEvent } from '../../connection';
 import { documents, parser } from '..';
 import Linter from '../../language/linter';
 import Cache from '../../language/models/cache';
@@ -21,6 +21,10 @@ export async function initialise() {
 				case FileChangeType.Created:
 				case FileChangeType.Changed:
 					loadFile(fileEvent.uri);
+
+					if (fileEvent.uri.toLowerCase().endsWith(`.rpgleinc`)) {
+						currentIncludes = undefined;
+					}
 					break;
 
 				default:
@@ -61,6 +65,14 @@ async function loadFile(uri: string) {
 			}
 		});
 	}
+}
+
+let currentIncludes: PossibleInclude[]|undefined = [];
+
+export async function getIncludes(basePath: string) {
+	if (!currentIncludes || currentIncludes && currentIncludes.length === 0) currentIncludes = await getIncludesUris(basePath);
+
+	return currentIncludes;
 }
 
 export function findAllReferences(def: Declaration): Location[] {

--- a/tests/suite/linter.js
+++ b/tests/suite/linter.js
@@ -2185,7 +2185,8 @@ exports.linter30 = async () => {
     offset: {
       position: 6,
       end: 11
-    }
+    },
+    newValue: undefined
   });
 }
 

--- a/tests/suite/linter.js
+++ b/tests/suite/linter.js
@@ -2256,6 +2256,51 @@ exports.linter32 = async () => {
   assert.strictEqual(errors.length, 0);
 }
 
+exports.linter32_b = async () => {
+  const lines = [
+    `**FREE`,
+    ``,
+    `Ctl-Opt DftActGrp(*No);`,
+    ``,
+    `/copy 'copy1.rpgle'`,
+    ``,
+    `Dcl-s MyVariable2 Char(20);`,
+    ``,
+    `Dcl-C theConstant 'Hello world';`,
+    ``,
+    `CallP theExtProcedure(myVariable);`,
+    ``,
+    `Return;`
+  ].join(`\n`);
+
+  const parser = parserSetup();
+  const cache = await parser.getDocs(uri, lines);
+  const { errors } = Linter.getErrors({
+    uri, 
+    content: lines,
+    availableIncludes: [`tests/rpgle/copy1.rpgle`]
+  }, {
+    IncludeMustBeRelative: true
+  }, cache);
+
+  assert.strictEqual(cache.includes.length, 1);
+  assert.strictEqual(cache.includes[0].line, 4);
+
+  assert.strictEqual(errors.length, 1);
+
+  assert.deepStrictEqual(errors[0], {
+    type: `IncludeMustBeRelative`,
+    range: new Range(
+      new Position(4, 0),
+      new Position(4, 19),
+    ),
+    offset: {
+      position: 6,
+      end: 19
+    },
+    newValue: `'tests/rpgle/copy1.rpgle'`
+  });
+}
 
 exports.linter33 = async () => {
   const lines = [


### PR DESCRIPTION
### Changes

An addition to `IncludeMustBeRelative`. When Project mode is enabled (i.e. when there is a workspace), when this lint option is enabled, it will verify that the path is the actual path to the local file in the workspace relative to the root.

### Checklist

* [x] have tested my change
* [x] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
