### PR TITLE
Do not require parameters for procedures found in control options

### DIFF
--- a/server/src/language/linter.js
+++ b/server/src/language/linter.js
@@ -1008,7 +1008,10 @@ export default class Linter {
                           const definedProcedure = globalProcs.find(proc => proc.name.toUpperCase() === upperName);
                           if (definedProcedure) {
                             let requiresBlock = false;
-                            if (statement.length <= i + 1) {
+                            // Don't require parms for procedures found in Ctl-Opt
+                            if (statement[0].value.toUpperCase() === `CTL-OPT`) {
+                              // do nothing
+                            } else if (statement.length <= i + 1) {
                               requiresBlock = true;
                             } else if (statement[i + 1].type !== `openbracket`) {
                               requiresBlock = true;

--- a/tests/suite/linter.js
+++ b/tests/suite/linter.js
@@ -972,6 +972,24 @@ exports.linter8 = async () => {
   }, `Error not as expected`);
 };
 
+exports.linter_Do_Not_Require_Parameters_For_Control_Options = async () => {
+  const lines = [
+    `**FREE`,
+    `ctl-opt main(main) ;`,
+    `dcl-proc main ;`,
+    `  return ;`,
+    `end-proc main ;`,
+  ].join(`\n`);
+
+  const parser = parserSetup();
+  const cache = await parser.getDocs(uri, lines);
+  const { errors } = Linter.getErrors({ uri, content: lines }, {
+    RequiresParameter: true
+  }, cache);
+
+  assert.strictEqual(errors.length, 0, `Unexpected RequiresParamters error`);
+};
+
 /**
    * Check that local variables are not in global scope
    */


### PR DESCRIPTION
The "RequiresParameter" lint option should ignore procedure names found in the Ctl-Opts.  
Specific problem is when using "ctl-opt main(main)":
![image](https://user-images.githubusercontent.com/17951550/211212590-525b813c-e4ae-4983-bd46-c0380a8a7b70.png)

### Changes
Added a test case for this specific issue, and added a check to see if we're inside a control option.

### Checklist

* [x ] have tested my change
* [ ] updated relevant documentation
* [x ] Remove any/all `console.log`s I added
* [x ] eslint is not complaining [about these specific files]
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
