### PR TITLE
On-error statement shouldn't be considered individual words

### DIFF
--- a/server/src/language/statement.js
+++ b/server/src/language/statement.js
@@ -161,6 +161,17 @@ const commonMatchers = [
     becomes: {
       type: `builtin`
     }
+  },
+  {
+    name: `ON-ERROR`,
+    match: [
+      { type: `word`, match: (word) => word.toUpperCase() === `ON` },
+      { type: `minus` },
+      { type: `word`, match: (word) => word.toUpperCase() === `ERROR` },
+    ],
+    becomes: {
+      type: `word`
+    }
   }
 ];
 

--- a/tests/suite/linter.js
+++ b/tests/suite/linter.js
@@ -3159,6 +3159,27 @@ exports.linter40_keywordrefs = async () => {
   });
 }
 
+exports.linter_casing_on_error_not_a_variable = async () => {
+  const lines = [
+    `**free`,
+    `dcl-c  ERROR  -1;`,
+    `monitor;`,
+    `  callSomething();`,
+    `on-error;`,
+    `  result = ERROR;`,
+    `endmon;`,
+  ].join(`\n`);
+
+  const parser = parserSetup();
+  const cache = await parser.getDocs(uri, lines);
+  const { errors } = Linter.getErrors({ uri, content: lines }, {
+    CollectReferences: true,
+    IncorrectVariableCase: true
+  }, cache);
+
+  assert.strictEqual(errors.length, 0, `on-error should not throw a variable casing error`);
+}
+
 exports.issue_175 = async () => {
   const lines = [
     `**FREE`,


### PR DESCRIPTION
### Changes

Cause "on-error" to be considered a single word so that it won't cause "Variable name case" error.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
