### PR TITLE
Fix: Find all references

### DIFF
--- a/server/src/providers/reference.ts
+++ b/server/src/providers/reference.ts
@@ -13,9 +13,14 @@ export async function referenceProvider(params: ReferenceParams): Promise<Locati
 	if (document) {
 		const isFree = (document.getText(Range.create(0, 0, 0, 6)).toUpperCase() === `**FREE`);
 
-		const word = getWordRangeAtPosition(document, position);
+		let word = getWordRangeAtPosition(document, position)?.trim();
 
 		if (word) {
+      if (word.endsWith(`;`)) {
+        const pieces = word.split(`;`);
+        word = pieces[0];
+      }
+
 			const doc = await parser.getDocs(uri, document.getText());
 
 			if (doc) {


### PR DESCRIPTION
### Changes

The "find all references" command doesn't work when the word end with `;`. And I remove spaces.

### Checklist

* [X] have tested my change
* [X] updated relevant documentation
* [X] Remove any/all `console.log`s I added
* [X] eslint is not complaining
* [X] have added myself to the contributors' list in the README
* [X] **for feature PRs**: PR only includes one feature enhancement.
