### PR TITLE
Display 'Subroutine' keyword in full-free

### DIFF
--- a/server/src/language/parser.js
+++ b/server/src/language/parser.js
@@ -754,6 +754,7 @@ export default class Parser {
                 currentItem = new Declaration(`subroutine`);
                 currentItem.name = partsLower[1];
                 currentItem.description = currentDescription.join(` `);
+		currentItem.keywords = [`Subroutine`];
 
                 currentItem.position = {
                   path: file,


### PR DESCRIPTION
### Changes

Display 'Subroutine' keyword in full-free.
![image](https://user-images.githubusercontent.com/18192917/222098352-24c5ee91-7f01-41f3-9a4d-a7eafb71d541.png)

![image](https://user-images.githubusercontent.com/18192917/222098836-53681b1b-7d30-4547-810f-6f20d30505f8.png)


### Checklist

* [X] have tested my change
* [X] updated relevant documentation
* [X] Remove any/all `console.log`s I added
* [X] eslint is not complaining
* [X] have added myself to the contributors' list in the README
* [X] **for feature PRs**: PR only includes one feature enhancement.
