### PR TITLE
Fix for fetching lint config

### DIFF
--- a/server/src/providers/linter/codeActions.ts
+++ b/server/src/providers/linter/codeActions.ts
@@ -1,5 +1,5 @@
 import { CodeAction, CodeActionParams, Range } from 'vscode-languageserver';
-import { getActions, refreshDiagnostics } from '.';
+import { getActions, refreshLinterDiagnostics } from '.';
 import { documents, parser } from '..';
 
 export default async function codeActionsProvider(params: CodeActionParams): Promise<CodeAction[]|undefined> {
@@ -13,7 +13,7 @@ export default async function codeActionsProvider(params: CodeActionParams): Pro
 			const docs = await parser.getDocs(document.uri);
 
 			if (docs) {
-				const detail = await refreshDiagnostics(document, docs, false);
+				const detail = await refreshLinterDiagnostics(document, docs, false);
 				if (detail) {
 					const fixErrors = detail.errors.filter(error => range.start.line === error.range.start.line );
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -239,7 +239,7 @@ documents.onDidChangeContent(handler => {
 		}
 	).then(cache => {
 		if (cache) {
-			Linter.refreshDiagnostics(handler.document, cache);
+			Linter.refreshLinterDiagnostics(handler.document, cache);
 		}
 	});
 });


### PR DESCRIPTION
### Changes

Previously vscode-rpgle was trying to fetch the lint configuration every time a file was changed. Now it will only fetch when the file is opened.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
