### PR TITLE
Fix bug where struct subfields weren't appearing in content assist

### DIFF
--- a/extension/server/src/providers/completionItem.ts
+++ b/extension/server/src/providers/completionItem.ts
@@ -44,10 +44,10 @@ export default async function completionItemProvider(handler: CompletionParams):
 			// This means we're just looking for subfields in the struct
 			if (trigger === `.`) {
 				let currentPosition = Position.create(handler.position.line, handler.position.character - 2);
-				let preWord = getWordRangeAtPosition(document, currentPosition)?.toUpperCase();
+				let preWord = getWordRangeAtPosition(document, currentPosition);
 
 				// Uh oh! Maybe we found dim struct?
-				if (!preWord) {
+				if (preWord) {
 					const startBracket = currentLine.lastIndexOf(`(`, currentPosition.character);
 
 					if (startBracket > -1) {
@@ -58,6 +58,8 @@ export default async function completionItemProvider(handler: CompletionParams):
 
 				// Ok, we have a 'preWord' (the name of the struct?)
 				if (preWord) {
+					preWord = preWord.toUpperCase();
+					
 					// Look at the parms or existing structs to find a possible reference
 					const possibleStruct: Declaration | undefined = [
 						currentProcedure && currentProcedure.scope ? currentProcedure.scope.parameters.find(parm => parm.name.toUpperCase() === preWord && parm.subItems.length > 0) : undefined,


### PR DESCRIPTION
### Changes

Fix issue of struct not being resolving when references with in index.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
