### PR TITLE
Enhancements/big_project_mode

### DIFF
--- a/extension/client/src/linter.ts
+++ b/extension/client/src/linter.ts
@@ -78,7 +78,7 @@ export function initialise(context: ExtensionContext) {
 
 						case `streamfile`:
 							const config = instance.getConfig();
-							if (config.homeDirectory) {
+							if (config && config.homeDirectory) {
 								configPath = path.posix.join(config.homeDirectory, `.vscode`, `rpglint.json`)
 							}
 							break;

--- a/extension/client/src/requests.ts
+++ b/extension/client/src/requests.ts
@@ -100,16 +100,20 @@ export default function buildRequestHandlers(client: LanguageClient) {
 
 		const instance = getInstance();
 
-		const content = instance?.getContent();
-		const config = instance?.getConfig()!;
+		if (instance) {
+			const content = instance?.getContent();
+			const config = instance?.getConfig()!;
 
-		if (includePaths.length === 0) {
-			includePaths.push(config.homeDirectory);
+			if (content && config) {
+				if (includePaths.length === 0) {
+					includePaths.push(config.homeDirectory);
+				}
+
+				const resolvedPath = await content?.streamfileResolve(bases, includePaths);
+
+				return resolvedPath;
+			}
 		}
-
-		const resolvedPath = await content?.streamfileResolve(bases, includePaths);
-
-		return resolvedPath;
  });
 
 	/**

--- a/extension/server/src/providers/definition.ts
+++ b/extension/server/src/providers/definition.ts
@@ -14,7 +14,7 @@ export default async function definitionProvider(handler: DefinitionParams): Pro
 			const possibleInclude = Parser.getIncludeFromDirective(editingLine);
 
 			if (possibleInclude) {
-				const include = await parser.includeFileFetch(currentPath, possibleInclude);
+				const include = await parser.includeFileFetch(currentPath, possibleInclude.content);
 				if (include.found && include.uri) {
 					return Location.create(include.uri, Range.create(0, 0, 0, 0));
 				}

--- a/extension/server/src/providers/hover.ts
+++ b/extension/server/src/providers/hover.ts
@@ -95,8 +95,8 @@ export default async function hoverProvider(params: HoverParams): Promise<Hover|
 					const includeDirective = Parser.getIncludeFromDirective(lineContent);
 					
 					if (includeDirective) {
-						const include = await parser.includeFileFetch(currentPath, includeDirective);
-						let displayName = includeDirective;
+						const include = await parser.includeFileFetch(currentPath, includeDirective.content);
+						let displayName = includeDirective.content;
 
 						if (include.found && include.uri) {
 							const foundUri = URI.parse(include.uri);

--- a/language/parser.js
+++ b/language/parser.js
@@ -311,11 +311,8 @@ export default class Parser {
         if (includePath) {
           const isAllowed = includePath.isMember === false || (includePath.isMember && options.butIgnoreMembers !== true);
 
-          console.log({includePath, isAllowed});
-
           if (isAllowed) {
             const include = await this.includeFileFetch(workingUri, includePath.content);
-            console.log(include);
             if (include.found) {
               files[include.uri] = include.lines;
               scopes[0].includes.push({


### PR DESCRIPTION
### Changes

Project Mode for local development was disabled if the project was over a certain size due to the sheer size of memory required, though this is normal for IDEs, IBM i developers weren't expecting it. This is because people traditionally used to developing on the server.

This PR cleans up the performance of loading projects into memory and has a way to enable Project Mode via `iproj.json` for specific projects.

Things left to do:

* [ ] Ensure member includes continue to work for streamfiles and members

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
