### PR TITLE
Change link to releases on the change log page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,4 @@
 # Change Log
 
-All notable changes to the "vscode-rpgle" extension will be documented in this file.
-
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
-
-## [Unreleased]
-
-- Initial release
+All notable changes to the "vscode-rpgle" extension can be found in the
+[Releases](https://github.com/codefori/vscode-rpgle/releases) section of the GitHub repository.


### PR DESCRIPTION
### Changes

This PR will fix the link on the change log page to point to the releases section of this GitHub repository.

### Checklist

* [x] have tested my change
