### PR TITLE
Add code action to generate binder source

### DIFF
--- a/extension/client/src/commands.ts
+++ b/extension/client/src/commands.ts
@@ -1,4 +1,4 @@
-import { commands, ExtensionContext, Uri, window, workspace } from "vscode";
+import { commands, ExtensionContext, Uri, ViewColumn, window, workspace } from "vscode";
 import { clearTableCache, getCache } from "./requests";
 import { LanguageClient } from "vscode-languageclient/node";
 
@@ -6,7 +6,7 @@ export function registerCommands(context: ExtensionContext, client: LanguageClie
   context.subscriptions.push(
     commands.registerCommand(`vscode-rpgle.generateBinderSource`, async (content: string) => {
       const document = await workspace.openTextDocument({ language: `bnd`, content: content });
-      await window.showTextDocument(document);
+      await window.showTextDocument(document, ViewColumn.Beside);
     }),
 
     commands.registerCommand(`vscode-rpgle.server.reloadCache`, () => {

--- a/extension/client/src/commands.ts
+++ b/extension/client/src/commands.ts
@@ -1,9 +1,14 @@
-import { commands, ExtensionContext, Uri, window } from "vscode";
+import { commands, ExtensionContext, Uri, window, workspace } from "vscode";
 import { clearTableCache, getCache } from "./requests";
 import { LanguageClient } from "vscode-languageclient/node";
 
 export function registerCommands(context: ExtensionContext, client: LanguageClient) {
   context.subscriptions.push(
+    commands.registerCommand(`vscode-rpgle.generateBinderSource`, async (content: string) => {
+      const document = await workspace.openTextDocument({ language: `bnd`, content: content });
+      await window.showTextDocument(document);
+    }),
+
     commands.registerCommand(`vscode-rpgle.server.reloadCache`, () => {
       clearTableCache(client);
     }),


### PR DESCRIPTION
### Changes

Implements https://github.com/codefori/vscode-rpgle/issues/281

Added new code action:

<img width="924" height="444" alt="image" src="https://github.com/user-attachments/assets/b159ea66-d54f-4796-8758-c7b906df2b76" />

Generates binder source in new file:

<img width="2496" height="1302" alt="image" src="https://github.com/user-attachments/assets/2aa44cd5-4a89-4dbe-9e39-706c205f47cf" />


### Checklist

* [x] have tested my change
* [x] Remove any/all `console.log`s I added
* [x] **for feature PRs**: PR only includes one feature enhancement.
