### PR TITLE
Fix #482: `/IF DEFINED` to recognize lowercase `/DEFINE` macros

### DIFF
--- a/language/parser.ts
+++ b/language/parser.ts
@@ -805,7 +805,8 @@ export default class Parser {
                 let keywords = Parser.expandKeywords(expr);
 
                 if (typeof keywords[`DEFINED`] === `string`) {
-                  condition = definedMacros.includes(keywords[`DEFINED`]);
+                  // Keywords are not uppercased at this point, but defined macros are always uppercased, so we need to uppercase the keyword before checking.
+                  condition = definedMacros.includes(keywords[`DEFINED`].toUpperCase());
                 }
 
                 if (hasNot) condition = !condition;

--- a/tests/suite/directives.test.ts
+++ b/tests/suite/directives.test.ts
@@ -674,3 +674,54 @@ test('test copy with *libl', async () => {
   const valueB = Parser.getIncludeFromDirective(`/copy *libl/qrpgleref,stufh`);
   expect(valueB).toBe(`*libl/qrpgleref,stufh`);
 });
+
+test('/IF DEFINED - uppercase', async () => {
+  const lines = [
+    `**FREE`,
+    `/DEFINE MYMACRO`,
+    `/IF NOT DEFINED(MYMACRO)`,
+    `Dcl-S Var1 char(10);`,
+    `/ELSE`,
+    `Dcl-S Var2 char(10);`,
+    `/ENDIF`,
+    `Return;`
+  ].join(`\n`);
+
+  const cache = await parser.getDocs(uri, lines, { withIncludes: true, ignoreCache: true });
+  expect(cache.variables.length).toBe(1);
+  expect(cache.variables[0].name).toBe('Var2');
+});
+
+test('/IF DEFINED - lowercase', async () => {
+  const lines = [
+    `**FREE`,
+    `/define mymacro`,
+    `/if not defined(mymacro)`,
+    `Dcl-S Var1 char(10);`,
+    `/else`,
+    `Dcl-S Var2 char(10);`,
+    `/endif`,
+    `Return;`
+  ].join(`\n`);
+
+  const cache = await parser.getDocs(uri, lines, { withIncludes: true, ignoreCache: true });
+  expect(cache.variables.length).toBe(1);
+  expect(cache.variables[0].name).toBe('Var2');
+});
+
+test('/IF DEFINED with Not - mixed case', async () => {
+  const lines = [
+    `**FREE`,
+    `/DEFINE MYMACRO`,
+    `/IF Not DEFINED(MYMACRO)`,
+    `Dcl-S Var1 char(10);`,
+    `/ELSE`,
+    `Dcl-S Var2 char(10);`,
+    `/ENDIF`,
+    `Return;`
+  ].join(`\n`);
+
+  const cache = await parser.getDocs(uri, lines, { withIncludes: true, ignoreCache: true });
+  expect(cache.variables.length).toBe(1);
+  expect(cache.variables[0].name).toBe('Var2');
+});


### PR DESCRIPTION
### Changes

Previously, only uppercase macro names were detected in `/IF DEFINED(...)`. This update makes macro lookup case-insensitive, so both lowercase and uppercase macros are correctly recognized.

See #482 for a full description of the issue.