### PR TITLE
fix: ruler outline bar shifts editor content to the right closes #488 and #489

### DIFF
--- a/extension/client/src/language/columnAssist.ts
+++ b/extension/client/src/language/columnAssist.ts
@@ -22,7 +22,7 @@ import { SpecFieldDef, SpecFieldValue, SpecRulers, specs } from '../schemas/spec
 
 const getAreasForLine = (line: string, index: number) => {
   if (line.length < 6) return undefined;
-  if (line[6] === `*`) return undefined;
+  if (line[6] === `*` || line[6] === `/`) return undefined;
 
   const specLetter = line[5].toUpperCase();
   if (specs[specLetter]) {
@@ -33,6 +33,12 @@ const getAreasForLine = (line: string, index: number) => {
     return {
       specification,
       active,
+      outline: SpecRulers[specLetter]
+    };
+  } else if (SpecRulers[specLetter]) {
+    return {
+      specification: [] as SpecFieldDef[],
+      active: -1,
       outline: SpecRulers[specLetter]
     };
   }

--- a/extension/client/src/schemas/specs.ts
+++ b/extension/client/src/schemas/specs.ts
@@ -2,10 +2,12 @@ export type SpecFieldValue = {value: string, text: string};
 export type SpecFieldDef = {id: string, name: string, start: number, end: number, values?: SpecFieldValue[], padStart?: boolean}
 
 export const SpecRulers: {[spec: string]: string} = {
-  C: `.....CL0N01Factor1+++++++Opcode&ExtFactor2+++++++Result++++++++Len++D+HiLoEq`,
-  D: `.....DName+++++++++++ETDsFrom+++To/L+++IDc.Keywords++++++++++++++++++++`,
-  F: `.....FFilename++IPEASFRlen+LKlen+AIDevice+.Keywords++++++++++++++++++++`,
-  P: `.....PName+++++++++++..T...................Keywords++++++++++++++++++++`
+  C: `.....CL0N01Factor1+++++++Opcode&ExtFactor2+++++++Result++++++++Len++D+HiLoEq....`,
+  D: `.....DName+++++++++++ETDsFrom+++To/L+++IDc.Keywords+++++++++++++++++++++++++++++`,
+  F: `.....FFilename++IPEASFRlen+LKlen+AIDevice+.Keywords+++++++++++++++++++++++++++++`,
+  I: `.....IFilename++SqNORiPos1+NCCPos2+NCCPos3+NCCDcField+++++++++L1M1FrPlMnZr......`,
+  O: `.....OFilename++DF..N01N02N03Excnam++++B++A++Sb+Sa+.Constant/Editword/DateFormat`,
+  P: `.....PName+++++++++++..T...................Keywords+++++++++++++++++++++++++++++`
 }
 
 export const specs: {[spec: string]: SpecFieldDef[]} = {


### PR DESCRIPTION
## Problem

The fixed-format ruler (Shift+F4 / `toggleFixedRuler`) applies a `before.contentText` decoration to `lineNumber-1` using `opacity: 0` on `outlineBar` to visually hide that line's real content. However, VS Code still allocates **horizontal layout space** for the hidden text, so that line expands to approximately 160 characters wide in the layout engine.

This causes:
- Column guide decorations from other extensions (e.g. rpgiv2free's RPG Columnar Guides) to visually shift to the right when the ruler is active
- Potential horizontal scroll position changes in the editor

## Fix

Attach the ruler `before.contentText` decoration to **the current line** at column 0, with `margin: -1.4em 0 0 0` so it floats visually one line above — without touching the actual previous line in the layout at all.

`outlineBar` decoration type is simplified to `{}` since it no longer needs to hide anything.

## Changes

- `extension/client/src/language/columnAssist.ts`
