### PR TITLE
feat: support multiple alias columns (WHALISn) in dspffdToRecordFormats

### DIFF
--- a/extension/server/src/data.ts
+++ b/extension/server/src/data.ts
@@ -16,6 +16,22 @@ export function parseMemberUri(path: string): {asp?: string, library?: string, f
 	}
 };
 
+function getAliasNames(row: any): string[] {
+	const aliasKeys = Object.keys(row)
+		.filter(key => key === `WHALIS` || /^WHALI\d+$/.test(key))
+		.sort((a, b) => {
+			const aNum = a === `WHALIS` ? 0 : Number(a.replace(`WHALI`, ``));
+			const bNum = b === `WHALIS` ? 0 : Number(b.replace(`WHALI`, ``));
+			return aNum - bNum;
+		});
+
+	return aliasKeys
+		.map(key => row[key])
+		.filter((value): value is string => typeof value === `string`)
+		.map(value => value.trim())
+		.filter(value => value.length > 0);
+}
+
 export function dspffdToRecordFormats(data: any, aliases = false): Declaration[] {
 	let recordFormats: {[name: string]: Declaration} = {};
 
@@ -23,17 +39,26 @@ export function dspffdToRecordFormats(data: any, aliases = false): Declaration[]
 		const {
 			WHNAME: formatName,
 			WHFLDT: type,
-			WHFLDB: strLength, 
+			WHFLDB: strLength,
 			WHFLDD: digits,
 			WHFLDP: decimals,
 			WHFTXT: text,
 		} = row;
 
-		const aliasName: string|undefined = row.WHALIS ? row.WHALIS.trim() : undefined;
-		const name = aliases ? aliasName || row.WHFLDE : row.WHFLDE;
+		const aliasNames = getAliasNames(row);
+		const systemName = (row.WHFLDE as string).trim();
+		const names: string[] = [];
 
-		if (name.trim() === ``) return;
-		if (name.startsWith(`*`)) return;
+		if (aliases && aliasNames.length > 0) {
+			for (const alias of aliasNames) {
+				if (alias !== systemName && !names.includes(alias)) {
+					names.push(alias);
+				}
+			}
+		}
+		names.push(systemName);
+
+		if (names.some(n => n === `` || n.startsWith(`*`))) return;
 
 		let recordFormat;
 		if (recordFormats[formatName]) {
@@ -44,13 +69,10 @@ export function dspffdToRecordFormats(data: any, aliases = false): Declaration[]
 			recordFormats[formatName] = recordFormat;
 		}
 
-		const currentSubfield = new Declaration(`subitem`);
-		currentSubfield.name = name;
 		let keywords: {[key: string]: string|true} = {};
-
 		if (row.WHVARL === `Y`) keywords[`VARYING`] = true;
 
-		currentSubfield.keyword = getPrettyType({
+		const keywordValue = getPrettyType({
 			type,
 			len: digits === 0 ? strLength : digits,
 			decimals: decimals,
@@ -58,10 +80,14 @@ export function dspffdToRecordFormats(data: any, aliases = false): Declaration[]
 			field: ``,
 			pos: ``
 		});
-		
-		currentSubfield.tags.push({tag: `description`, content: text.trim()});
 
-		recordFormat.subItems.push(currentSubfield);
+		for (const name of names) {
+			const currentSubfield = new Declaration(`subitem`);
+			currentSubfield.name = name;
+			currentSubfield.keyword = keywordValue;
+			currentSubfield.tags.push({tag: `description`, content: text.trim()});
+			recordFormat.subItems.push(currentSubfield);
+		}
 	});
 
 	return Object.values(recordFormats);

--- a/tests/suite/data.test.ts
+++ b/tests/suite/data.test.ts
@@ -1,0 +1,120 @@
+import { test, expect } from "vitest";
+import { dspffdToRecordFormats } from "../../extension/server/src/data";
+
+test("dspffd alias mode emits all aliases and system name when they differ", () => {
+  const data = [
+    {
+      WHNAME: "LONGTABLE",
+      WHFLDE: "SYSNAME",
+      WHFLDT: "A",
+      WHFLDB: 50,
+      WHFLDD: 0,
+      WHFLDP: 0,
+      WHFTXT: "",
+      WHVARL: "N",
+      WHALIS: "THIS_IS_A_VERY_LONG_ALIAS_NAME",
+      WHALI2: "THIS_IS_A_VERY_LONG_ALIAS_NAME_12345"
+    }
+  ];
+
+  const recordFormats = dspffdToRecordFormats(data, true);
+
+  expect(recordFormats.length).toBe(1);
+  expect(recordFormats[0].subItems.length).toBe(3);
+  expect(recordFormats[0].subItems[0].name).toBe("THIS_IS_A_VERY_LONG_ALIAS_NAME");
+  expect(recordFormats[0].subItems[1].name).toBe("THIS_IS_A_VERY_LONG_ALIAS_NAME_12345");
+  expect(recordFormats[0].subItems[2].name).toBe("SYSNAME");
+});
+
+test("dspffd non-alias mode emits only system name", () => {
+  const data = [
+    {
+      WHNAME: "LONGTABLE",
+      WHFLDE: "SYSNAME",
+      WHFLDT: "A",
+      WHFLDB: 50,
+      WHFLDD: 0,
+      WHFLDP: 0,
+      WHFTXT: "",
+      WHVARL: "N",
+      WHALIS: "THIS_IS_A_VERY_LONG_ALIAS_NAME",
+      WHALI2: "THIS_IS_A_VERY_LONG_ALIAS_NAME_12345"
+    }
+  ];
+
+  const recordFormats = dspffdToRecordFormats(data, false);
+
+  expect(recordFormats.length).toBe(1);
+  expect(recordFormats[0].subItems.length).toBe(1);
+  expect(recordFormats[0].subItems[0].name).toBe("SYSNAME");
+});
+
+test("dspffd alias falls back to system field name", () => {
+  const data = [
+    {
+      WHNAME: "LONGTABLE",
+      WHFLDE: "SYSTEM_FIELD",
+      WHFLDT: "A",
+      WHFLDB: 10,
+      WHFLDD: 0,
+      WHFLDP: 0,
+      WHFTXT: "",
+      WHVARL: "N",
+      WHALIS: "",
+      WHALI2: ""
+    }
+  ];
+
+  const recordFormats = dspffdToRecordFormats(data, true);
+
+  expect(recordFormats.length).toBe(1);
+  expect(recordFormats[0].subItems.length).toBe(1);
+  expect(recordFormats[0].subItems[0].name).toBe("SYSTEM_FIELD");
+});
+
+test("dspffd alias mode emits only system name when alias equals system name", () => {
+  const data = [
+    {
+      WHNAME: "LONGTABLE",
+      WHFLDE: "SYSNAME",
+      WHFLDT: "A",
+      WHFLDB: 10,
+      WHFLDD: 0,
+      WHFLDP: 0,
+      WHFTXT: "",
+      WHVARL: "N",
+      WHALIS: "SYSNAME",
+      WHALI2: ""
+    }
+  ];
+
+  const recordFormats = dspffdToRecordFormats(data, true);
+
+  expect(recordFormats.length).toBe(1);
+  expect(recordFormats[0].subItems.length).toBe(1);
+  expect(recordFormats[0].subItems[0].name).toBe("SYSNAME");
+});
+
+
+test("dspffd alias mode emits only system name when alias equals system name", () => {
+  const data = [
+    {
+      WHNAME: "LONGTABLE",
+      WHFLDE: "SYSNAME",
+      WHFLDT: "A",
+      WHFLDB: 10,
+      WHFLDD: 0,
+      WHFLDP: 0,
+      WHFTXT: "",
+      WHVARL: "N",
+      WHALIS: "SYSNAME",
+      WHALI2: "SYSNAME"
+    }
+  ];
+
+  const recordFormats = dspffdToRecordFormats(data, true);
+
+  expect(recordFormats.length).toBe(1);
+  expect(recordFormats[0].subItems.length).toBe(1);
+  expect(recordFormats[0].subItems[0].name).toBe("SYSNAME");
+});


### PR DESCRIPTION
### Changes

When `dspffd` data contains multiple alias columns (`WHALIS`, `WHALI2`, `WHALI3`, …), `dspffdToRecordFormats` previously only considered the single `WHALIS` column. This meant any additional alias names were silently dropped.

This PR introduces a `getAliasNames` helper that collects all `WHALISn`-style columns from a row, sorts them by their numeric suffix, and returns unique non-empty values. When alias mode is enabled, `dspffdToRecordFormats` now emits a `subItem` for each distinct alias that differs from the system name (`WHFLDE`), followed by one `subItem` for the system name itself — keeping backward compatibility when no extra alias columns are present.

**Files changed:**
- data.ts — added `getAliasNames`, updated `dspffdToRecordFormats` to loop over all collected names
- data.test.ts — new test suite covering: multiple aliases, non-alias mode, empty alias fallback, and deduplication when alias equals system name

### Checklist

* [x] have tested my change
* [x] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.