### PR TITLE
use QTEMP for DSPFFD instead of ILEDITOR

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,4 @@ Thanks so much to everyone [who has contributed](https://github.com/codefori/vsc
 - [@SanjulaGanepola](https://github.com/SanjulaGanepola)
 - [@bobcozzi](https://github.com/bobcozzi)
 - [@Mohammed-Yaseen-Ali-2081](https://github.com/Mohammed-Yaseen-Ali-2081)
+- [@eric-simpson](https://github.com/eric-simpson)

--- a/extension/client/src/requests.ts
+++ b/extension/client/src/requests.ts
@@ -133,7 +133,7 @@ export function buildRequestHandlers(client: LanguageClient) {
 
 				const dateStr = Date.now().toString().substr(-6);
 				const randomFile = `R${table.substring(0, 3)}${dateStr}`.substring(0, 10);
-				const fullPath = `${config.tempLibrary}/${randomFile}`;
+				const fullPath = `QTEMP/${randomFile}`;
 
 				console.log(`Temp OUTFILE: ${fullPath}`);
 
@@ -161,7 +161,7 @@ export function buildRequestHandlers(client: LanguageClient) {
 				const resultCode = outfileRes.code || 0;
 
 				if (resultCode === 0) {
-					const data: any[] = await content.getTable(config.tempLibrary, randomFile, randomFile, true);
+					const data: any[] = await content.getTable('QTEMP', randomFile, randomFile, true);
 
 					console.log(`Temp OUTFILE read. ${data.length} rows.`);
 


### PR DESCRIPTION
### Changes

Use QTEMP for output of DSPFFD instead of ILEDITOR to avoid security exposure of user data
Fix #524 

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [x] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
