### PR TITLE
Fix LINTER configuration creation crash

### DIFF
--- a/extension/client/src/language/serverReferences.ts
+++ b/extension/client/src/language/serverReferences.ts
@@ -1,7 +1,7 @@
+import { ConnectionConfig, IBMiMember } from "@halcyontech/vscode-ibmi-types";
+import IBMi from "@halcyontech/vscode-ibmi-types/api/IBMi";
 import { commands, Definition, DocumentSymbol, languages, Location, ProgressLocation, Range, SymbolInformation, SymbolKind, TextDocument, Uri, window, workspace } from "vscode";
 import { getInstance } from "../base";
-import IBMi from "@halcyontech/vscode-ibmi-types/api/IBMi";
-import { ConnectionConfig, IBMiMember } from "@halcyontech/vscode-ibmi-types";
 
 export function getServerSymbolProvider() {
   let latestFetch: ExportInfo[]|undefined;
@@ -18,7 +18,7 @@ export function getServerSymbolProvider() {
 
       if (instance && instance.getConnection()) {
         const connection = instance.getConnection();
-        const config = connection.config! //TODO in vscode-ibmi 3.0.0 - change to getConfig()
+        const config = connection.getConfig();
 
         let member: IBMiMember|undefined;
 
@@ -71,7 +71,7 @@ export function getServerImplementationProvider() {
 
       if (connection) {
         const word = document.getText(document.getWordRangeAtPosition(position));
-        const config = connection.getConfig() //TODO in vscode-ibmi 3.0.0 - change to getConfig()
+        const config = connection.getConfig();
 
         const uriPath = document.uri.path;
         const member = connection.parserMemberPath(uriPath);

--- a/extension/client/src/linter.ts
+++ b/extension/client/src/linter.ts
@@ -1,8 +1,8 @@
 import path = require('path');
 import { commands, ExtensionContext, Uri, ViewColumn, window, workspace } from 'vscode';
-import {getInstance} from './base';
+import { getInstance } from './base';
 
-import {DEFAULT_SCHEMA} from "./schemas/linter"
+import { DEFAULT_SCHEMA } from "./schemas/linter";
 
 export function initialise(context: ExtensionContext) {
 	context.subscriptions.push(
@@ -47,7 +47,7 @@ export function initialise(context: ExtensionContext) {
 
 			} else if (instance && instance.getConnection()) {
 				const connection = instance.getConnection();
-				const content = instance.getContent();
+				const content = connection.getContent();
 
 				/** @type {"member"|"streamfile"} */
 				let type = `member`;
@@ -142,7 +142,7 @@ export function initialise(context: ExtensionContext) {
 												try {
 													console.log(`Member path: ${[memberPath[0], `VSCODE`, `RPGLINT`].join(`/`)}`);
 
-													await content.uploadMemberContent(undefined, memberPath[0], `VSCODE`, `RPGLINT`, jsonString);
+													await content.uploadMemberContent(memberPath[0], `VSCODE`, `RPGLINT`, jsonString);
 													await commands.executeCommand(`code-for-ibmi.openEditable`, configPath);
 												} catch (e) {
 													console.log(e);
@@ -155,7 +155,7 @@ export function initialise(context: ExtensionContext) {
 											console.log(`IFS path: ${configPath}`);
 
 											try {
-												await content.writeStreamfile(configPath, jsonString);
+												await content.writeStreamfileRaw(configPath, jsonString, "utf-8");
 												await commands.executeCommand(`code-for-ibmi.openEditable`, configPath);
 											} catch (e) {
 												console.log(e);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"hasInstallScript": true,
 			"license": "MIT",
 			"devDependencies": {
-				"@halcyontech/vscode-ibmi-types": "^2.11.0",
+				"@halcyontech/vscode-ibmi-types": "^3.0.10",
 				"@types/node": "^20.19.41",
 				"@typescript-eslint/eslint-plugin": "^5.30.0",
 				"@typescript-eslint/parser": "^5.30.0",
@@ -605,9 +605,9 @@
 			}
 		},
 		"node_modules/@halcyontech/vscode-ibmi-types": {
-			"version": "2.18.0",
-			"resolved": "https://registry.npmjs.org/@halcyontech/vscode-ibmi-types/-/vscode-ibmi-types-2.18.0.tgz",
-			"integrity": "sha512-gHoLJW+wFG3uuGxnwXmCn7xRg5v4zqidAZmq6W/SS2m8v6CUl5ZXEb2S653gB1yY0VzQG8F2azD6CXw7EFT0dw==",
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@halcyontech/vscode-ibmi-types/-/vscode-ibmi-types-3.0.10.tgz",
+			"integrity": "sha512-8rby5IOfJYNOLf62P0pYqY3tXTbiR18jAD1Jtwm7BfN3+kfJ4XM2v3Fg/Lc5jLzBo8Ql1UMLemaEjOqcbCuB6g==",
 			"dev": true,
 			"license": "ISC"
 		},

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
 		"cli:dev:rpglint": "cd cli/rpglint && npm run webpack:dev"
 	},
 	"devDependencies": {
-		"@halcyontech/vscode-ibmi-types": "^2.11.0",
+		"@halcyontech/vscode-ibmi-types": "^3.0.10",
 		"@types/node": "^20.19.41",
 		"@typescript-eslint/eslint-plugin": "^5.30.0",
 		"@typescript-eslint/parser": "^5.30.0",


### PR DESCRIPTION
### Changes
Fixes #532

`uploadMemberContent` was called with the wrong paramters, leading to the library parameter being `undefined`. 

This PR bumps the Code for i types to 3.0.10 and fixes the `uploadMemberContent` call.

### Checklist

* [x] have tested my change