### PR TITLE
Add comment/uncomment functionality for RPGLE

### DIFF
--- a/extension/client/src/commentStmt.ts
+++ b/extension/client/src/commentStmt.ts
@@ -1,0 +1,368 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 1996-2026 by R. Cozzi, Jr.
+// @author BobCozzi
+
+import * as vscode from 'vscode';
+import * as rpgle from './rpgtools-comment-helpers';
+
+export function registerCommentStatementCommand(context: vscode.ExtensionContext) {
+  const disposable = vscode.commands.registerCommand('vscode-rpgle.commentStatement', async () => {
+    const editor = vscode.window.activeTextEditor;
+    rpgle.log('Comment Statement Handler evoked');
+
+    if (!editor) {
+      vscode.window.showErrorMessage('No active editor window found. Comment statement cancelled.');
+      return;
+    }
+
+    const doc = editor.document;
+    const allLines = doc.getText().split(rpgle.getEOL());
+    const isCompletelyFreeFormat = !rpgle.isFixedFormatRPG(doc);
+    const edits: vscode.TextEdit[] = [];
+
+    try {
+      for (const sel of editor.selections) {
+        const start = Math.min(sel.start.line, sel.end.line);
+        const end = Math.max(sel.start.line, sel.end.line);
+
+        for (let lineIndex = start; lineIndex <= end; lineIndex++) {
+          if (lineIndex >= allLines.length) continue;
+
+          const line = allLines[lineIndex];
+
+          // Skip lines that are already comments
+          if (rpgle.isComment(line, doc)) continue;
+
+          // Skip empty/blank/directive lines
+          if (rpgle.isSkipStmt(line, doc)) continue;
+
+          let commentedLine = '';
+
+          // If the file is **FREE, always use free format comments
+          if (isCompletelyFreeFormat) {
+            commentedLine = commentFreeFormatLine(line);
+          } else {
+            // For mixed format files, determine format by checking if the line has a valid spec type
+            const specType = rpgle.getSpecType(line);
+
+            // specType is valid only if it's a non-whitespace character (c, d, f, h, p, etc.)
+            if (specType && specType.trim() !== '') {
+              // Fixed format: Insert asterisk at column 7 (position 6, 0-indexed)
+              commentedLine = commentFixedFormatLine(line);
+            } else {
+              // Free format: Add // to the beginning
+              commentedLine = commentFreeFormatLine(line);
+            }
+          }
+
+          if (commentedLine !== '') {
+            const range = doc.lineAt(lineIndex).range;
+            edits.push(vscode.TextEdit.replace(range, commentedLine));
+          }
+        }
+      }
+
+      if (edits.length > 0) {
+        const edit = new vscode.WorkspaceEdit();
+        edit.set(doc.uri, edits);
+        await vscode.workspace.applyEdit(edit);
+      } else {
+        vscode.window.showInformationMessage('No lines to comment.');
+      }
+    } catch (e) {
+      rpgle.log('Error in comment statement: ' + (e as Error).message);
+      vscode.window.showErrorMessage('An error occurred while commenting: ' + (e as Error).message);
+    }
+  });
+
+  context.subscriptions.push(disposable);
+}
+
+export function registerUncommentStatementCommand(context: vscode.ExtensionContext) {
+  const disposable = vscode.commands.registerCommand('vscode-rpgle.uncommentStatement', async () => {
+    const editor = vscode.window.activeTextEditor;
+    rpgle.log('Uncomment Statement Handler evoked');
+
+    if (!editor) {
+      vscode.window.showErrorMessage('No active editor window found. Uncomment statement cancelled.');
+      return;
+    }
+
+    const doc = editor.document;
+    const allLines = doc.getText().split(rpgle.getEOL());
+    const isCompletelyFreeFormat = !rpgle.isFixedFormatRPG(doc);
+    const edits: vscode.TextEdit[] = [];
+
+    try {
+      for (const sel of editor.selections) {
+        const start = Math.min(sel.start.line, sel.end.line);
+        const end = Math.max(sel.start.line, sel.end.line);
+
+        for (let lineIndex = start; lineIndex <= end; lineIndex++) {
+          if (lineIndex >= allLines.length) continue;
+
+          const line = allLines[lineIndex];
+
+          // Only process comment lines
+          if (!rpgle.isComment(line, doc)) continue;
+
+          let uncommentedLine = '';
+
+          // If the file is **FREE, always use free format uncomment
+          if (isCompletelyFreeFormat) {
+            uncommentedLine = uncommentFreeFormatLine(line);
+          } else {
+            // For mixed format files, determine format by checking for asterisk in column 7
+            if (line.length > 6 && line[6] === '*') {
+              // Fixed format: Remove asterisk from column 7 (position 6, 0-indexed)
+              uncommentedLine = uncommentFixedFormatLine(line);
+            } else {
+              // Free format: Remove // from the beginning
+              uncommentedLine = uncommentFreeFormatLine(line);
+            }
+          }
+
+          if (uncommentedLine !== '') {
+            const range = doc.lineAt(lineIndex).range;
+            edits.push(vscode.TextEdit.replace(range, uncommentedLine));
+          }
+        }
+      }
+
+      if (edits.length > 0) {
+        const edit = new vscode.WorkspaceEdit();
+        edit.set(doc.uri, edits);
+        await vscode.workspace.applyEdit(edit);
+      } else {
+        vscode.window.showInformationMessage('No lines to uncomment.');
+      }
+    } catch (e) {
+      rpgle.log('Error in uncomment statement: ' + (e as Error).message);
+      vscode.window.showErrorMessage('An error occurred while uncommenting: ' + (e as Error).message);
+    }
+  });
+
+  context.subscriptions.push(disposable);
+}
+
+/**
+ * Toggle comment for Cmd+/ (Mac) or Ctrl+/ (Windows/Linux) keyboard shortcut
+ * If any line in the selection is uncommented, comment all lines
+ * If all lines are commented, uncomment all lines
+ */
+export function registerToggleCommentCommand(context: vscode.ExtensionContext) {
+  const disposable = vscode.commands.registerCommand('vscode-rpgle.toggleComment', async () => {
+    const editor = vscode.window.activeTextEditor;
+    rpgle.log('Toggle Comment Handler evoked');
+
+    if (!editor) {
+      vscode.window.showErrorMessage('No active editor window found. Toggle comment cancelled.');
+      return;
+    }
+
+    const doc = editor.document;
+    const allLines = doc.getText().split(rpgle.getEOL());
+    const isCompletelyFreeFormat = !rpgle.isFixedFormatRPG(doc);
+
+    try {
+      // First pass: determine if we should comment or uncomment
+      // If ANY line is uncommented (and not empty/directive), we comment all
+      // If ALL lines are commented or empty/directive, we uncomment
+      let hasUncommentedCode = false;
+
+      for (const sel of editor.selections) {
+        const start = Math.min(sel.start.line, sel.end.line);
+        const end = Math.max(sel.start.line, sel.end.line);
+
+        for (let lineIndex = start; lineIndex <= end; lineIndex++) {
+          if (lineIndex >= allLines.length) continue;
+
+          const line = allLines[lineIndex];
+
+          // Skip empty/blank/directive lines for the decision
+          if (rpgle.isSkipStmt(line, doc) && !rpgle.isComment(line, doc)) continue;
+
+          // If we find any uncommented code line, we'll comment everything
+          if (!rpgle.isComment(line, doc)) {
+            hasUncommentedCode = true;
+            break;
+          }
+        }
+
+        if (hasUncommentedCode) break;
+      }
+
+      // Second pass: apply the appropriate action
+      const edits: vscode.TextEdit[] = [];
+
+      if (hasUncommentedCode) {
+        // Comment all lines (same logic as commentStatement)
+        for (const sel of editor.selections) {
+          const start = Math.min(sel.start.line, sel.end.line);
+          const end = Math.max(sel.start.line, sel.end.line);
+
+          for (let lineIndex = start; lineIndex <= end; lineIndex++) {
+            if (lineIndex >= allLines.length) continue;
+
+            const line = allLines[lineIndex];
+
+            // Skip lines that are already comments
+            if (rpgle.isComment(line, doc)) continue;
+
+            // Skip empty/blank/directive lines
+            if (rpgle.isSkipStmt(line, doc)) continue;
+
+            let commentedLine = '';
+
+            if (isCompletelyFreeFormat) {
+              commentedLine = commentFreeFormatLine(line);
+            } else {
+              const specType = rpgle.getSpecType(line);
+              if (specType && specType.trim() !== '') {
+                commentedLine = commentFixedFormatLine(line);
+              } else {
+                commentedLine = commentFreeFormatLine(line);
+              }
+            }
+
+            if (commentedLine !== '') {
+              const range = doc.lineAt(lineIndex).range;
+              edits.push(vscode.TextEdit.replace(range, commentedLine));
+            }
+          }
+        }
+      } else {
+        // Uncomment all lines (same logic as uncommentStatement)
+        for (const sel of editor.selections) {
+          const start = Math.min(sel.start.line, sel.end.line);
+          const end = Math.max(sel.start.line, sel.end.line);
+
+          for (let lineIndex = start; lineIndex <= end; lineIndex++) {
+            if (lineIndex >= allLines.length) continue;
+
+            const line = allLines[lineIndex];
+
+            // Only process comment lines
+            if (!rpgle.isComment(line, doc)) continue;
+
+            let uncommentedLine = '';
+
+            if (isCompletelyFreeFormat) {
+              uncommentedLine = uncommentFreeFormatLine(line);
+            } else {
+              if (line.length > 6 && line[6] === '*') {
+                uncommentedLine = uncommentFixedFormatLine(line);
+              } else {
+                uncommentedLine = uncommentFreeFormatLine(line);
+              }
+            }
+
+            if (uncommentedLine !== '') {
+              const range = doc.lineAt(lineIndex).range;
+              edits.push(vscode.TextEdit.replace(range, uncommentedLine));
+            }
+          }
+        }
+      }
+
+      if (edits.length > 0) {
+        const edit = new vscode.WorkspaceEdit();
+        edit.set(doc.uri, edits);
+        await vscode.workspace.applyEdit(edit);
+      }
+    } catch (e) {
+      rpgle.log('Error in toggle comment: ' + (e as Error).message);
+      vscode.window.showErrorMessage('An error occurred while toggling comments: ' + (e as Error).message);
+    }
+  });
+
+  context.subscriptions.push(disposable);
+}
+
+/**
+ * Comment a fixed format RPG line by inserting an asterisk at column 7 (position 6)
+ * and shifting everything from column 7 onwards one position to the right
+ * @param line The fixed format line to comment
+ * @returns The commented line
+ */
+function commentFixedFormatLine(line: string): string {
+  // Ensure line is at least 6 characters to have columns 1-6
+  if (line.length < 6) {
+    line = line.padEnd(6, ' ');
+  }
+
+  // Extract the parts:
+  // Columns 1-6 (positions 0-5): Line sequence/label and form type
+  // Columns 7+ (positions 6+): The statement
+  const prefix = line.substring(0, 6);      // Columns 1-6
+  const statement = line.substring(6);      // Columns 7+
+
+  // Create commented line: prefix + '*' + statement
+  // This inserts the asterisk at column 7 and shifts everything else right
+  let commentedLine = prefix + '*' + statement;
+
+  return commentedLine;
+}
+
+/**
+ * Uncomment a fixed format RPG line by removing the asterisk at column 7 (position 6)
+ * and shifting everything from column 8 onwards one position to the left
+ * @param line The commented fixed format line
+ * @returns The uncommented line
+ */
+function uncommentFixedFormatLine(line: string): string {
+  // Extract the parts:
+  // Columns 1-6 (positions 0-5): Line sequence/label and form type
+  // Column 7 (position 6): Should be '*'
+  // Columns 8+ (positions 7+): The statement
+  const prefix = line.substring(0, 6);      // Columns 1-6
+  const statement = line.substring(7);      // Columns 8+
+
+  // Create uncommented line: prefix + statement
+  // This removes the asterisk and shifts everything back left
+  let uncommentedLine = prefix + statement;
+
+  return uncommentedLine;
+}
+
+/**
+ * Comment a free format RPG line by adding // to the beginning
+ * Respects the indentation of the original line
+ * @param line The free format line to comment
+ * @returns The commented line
+ */
+function commentFreeFormatLine(line: string): string {
+  // Get the leading whitespace
+  const leadingWhitespace = line.match(/^\s*/)?.[0] || '';
+  const trimmedLine = line.trim();
+
+  // If the line is already a comment, skip it
+  if (trimmedLine.startsWith('//')) {
+    return '';
+  }
+
+  // Add // comment marker, preserving indentation
+  return leadingWhitespace + '// ' + trimmedLine;
+}
+
+/**
+ * Uncomment a free format RPG line by removing the // prefix
+ * @param line The commented free format line
+ * @returns The uncommented line
+ */
+function uncommentFreeFormatLine(line: string): string {
+  // Get the leading whitespace
+  const leadingWhitespace = line.match(/^\s*/)?.[0] || '';
+  const trimmedLine = line.trim();
+
+  // If the line doesn't start with //, skip it
+  if (!trimmedLine.startsWith('//')) {
+    return '';
+  }
+
+  // Remove the // comment marker and optional space after it
+  const uncommentedContent = trimmedLine.replace(/^\/\/\s?/, '');
+
+  // Restore the indentation
+  return leadingWhitespace + uncommentedContent;
+}

--- a/extension/client/src/extension.ts
+++ b/extension/client/src/extension.ts
@@ -9,6 +9,7 @@ import { workspace, ExtensionContext } from 'vscode';
 import * as Linter from "./linter";
 import * as columnAssist from "./language/columnAssist";
 import { registerBracketMatcher } from "./language/bracketMatcher";
+import { registerCommentStatementCommand, registerUncommentStatementCommand, registerToggleCommentCommand } from './commentStmt';
 
 
 import {
@@ -100,6 +101,9 @@ export function activate(context: ExtensionContext) {
 	Linter.initialise(context);
 	columnAssist.registerColumnAssist(context);
 	registerBracketMatcher(context);
+	registerCommentStatementCommand(context);
+	registerUncommentStatementCommand(context);
+	registerToggleCommentCommand(context);
 	
 	registerCommands(context, client);
 	

--- a/extension/client/src/rpgtools-comment-helpers.ts
+++ b/extension/client/src/rpgtools-comment-helpers.ts
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 1996-2026 by R. Cozzi, Jr.
+// @author BobCozzi
+//
+// Minimal RPG helper functions for comment/uncomment support
+// Extracted from rpgiv2free extension's rpgtools.ts
+
+import * as vscode from 'vscode';
+
+// Regex patterns used by isDirective
+const freeFormDirectiveRegex = /^\/[A-Za-z0-9]+(\s|$)/; // Matches /COPY, /INCLUDE, etc.
+const singleCharDirectiveRegex = /^\/[A-Za-z0-9]\s?/;   // Matches /X or /X[whitespace]
+const validCharRegex = /^[A-Za-z0-9]/;                  // Matches valid characters after '/'
+
+export function log(...args: any[]) {
+  console.log('[vscode-rpgle]', ...args);
+}
+
+export function getEOL(): string {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) return '\n'; // Default to LF if no editor
+  return editor.document.eol === vscode.EndOfLine.CRLF ? '\r\n' : '\n';
+}
+
+export function getCol(line: string | null | undefined, from: number, to?: number): string {
+  if (!line || from < 1) return '';
+  const end = to ?? from; // default 'to' to 'from' if not provided
+  if (end < from) return '';
+  line = line.padEnd(end, ' ');
+  return line.substring(from - 1, end);
+}
+
+// Return the RPG IV Fixed Format Specification Code (H F D I C O P) in lowercase
+// or blank/empty when it is not one of those or when position 7 is * or /
+export function getSpecType(line: string): string {
+  if (line.length < 6) return '';
+  const col7 = line[6];
+  if (col7 === '*' || col7 === '/') return '';
+  return line[5].toLowerCase();
+}
+
+export function isFixedFormatRPG(document?: vscode.TextDocument): boolean {
+  let doc: vscode.TextDocument | undefined = document;
+  if (!doc) {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return false;
+    doc = editor.document;
+  }
+  if (doc.lineCount === 0) return true; // Treat empty document as fixed format
+  const firstLine = doc.lineAt(0).text;
+
+  // Check if **FREE appears in columns 1-6 (case-insensitive)
+  // Per IBM rules, **FREE must be the only content on the line,
+  // however, anything after `**FREE` should be ignored, thus the real test
+  // is if line 1, position 1 to 6 contains `**FREE` case ignored.
+  const bIsFreeFormat = (firstLine.length >= 6 &&
+    firstLine.substring(0, 6).toUpperCase() === '**FREE');
+
+  return !bIsFreeFormat;
+}
+
+export function isFreeFormatRPG(document?: vscode.TextDocument): boolean {
+  let doc: vscode.TextDocument | undefined = document;
+  if (!doc) {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return false;
+    doc = editor.document;
+  }
+
+  if (doc.lineCount === 0) return false; // Treat empty document as fixed format
+  const firstLine = doc.lineAt(0).text;
+
+  // Check if **FREE appears in columns 1-6 (case-insensitive)
+  // Per IBM rules, **FREE must be the only content but the compiler
+  // ignores anything after `**FREE` that it detects
+  const bIsFreeFormat = (firstLine.length >= 6 &&
+    firstLine.substring(0, 6).toUpperCase() === '**FREE');
+
+  return bIsFreeFormat;
+}
+
+export function isComment(line: string, document?: vscode.TextDocument): boolean {
+  const isFreeFormat = document ? isFreeFormatRPG(document) : false;
+  // Classic RPG IV column-7 '*' comments are not valid in fully free-format (**FREE) source
+  const classicRPGStyle = !isFreeFormat && line.length > 6 && line[6] === '*';
+  const cppStyle = getCol(line, 8, 80).trimStart().startsWith('//') ||
+    getCol(line, 1, 80).trimStart().startsWith('//');
+  return classicRPGStyle || cppStyle;
+}
+
+export function isDirective(line: string, bFreeFormOnly?: boolean): boolean {
+  // Classic RPG directive: column 7 is '/' and column 8 is not '/'
+  const bDirective = (
+    line.length > 7 &&
+    line[6] === '/' &&
+    line[7] !== '/'
+  );
+  if (bFreeFormOnly !== true) {
+    if (bDirective) return true;
+  }
+
+  //  /FREE
+  //  /END-FREE
+  //  /TITLE
+  //  /EJECT
+  //  /SPACE
+  //  /SET     [CCSID() | DATFMT() | TIMFMT()]
+  //  /RESTORE /* restored a prior /SET operation to what it was before /SET */
+  //  /OVERLOAD [DETAIL | NODETAIL]
+  //  /CHARCOUNT [NATURAL | STDCHARSIZE]
+  //  /COPY  library/file,source-member
+  //  /INCLUDE ["hiarchical-file-system-name" | library/source-file,source-member]
+  //  /DEFINE symbol
+  //  /UNDEFINE symbol
+  //  /IF [NOT [condition | DEFINED(symbol)]]
+  //  /ELSE
+  //  /ENDIF
+
+  // Free-form or modern: line starts with '/' followed by A-Za-z0-9
+  const trimmed = getCol(line, 7, 80).trim(); // Avoid converting to uppercase unnecessarily
+  if (!trimmed.startsWith('//') &&
+    trimmed.startsWith('/') &&
+    trimmed.length > 1 &&
+    validCharRegex.test(trimmed[1])
+  ) {
+    // Accept if only /X or /X[whitespace...]
+    if (singleCharDirectiveRegex.test(trimmed)) {
+      return true;
+    }
+    // Accept if /COPY, /INCLUDE, etc.
+    if (freeFormDirectiveRegex.test(trimmed)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Determines if a line represents an empty statement (no executable content).
+ * Supports fixed format, hybrid free format (column 8-80), and full free format RPG IV.
+ * Includes directives as empty statements.
+ *
+ * @param line - The source line to check
+ * @param document - Optional document for format detection; if not provided, uses heuristics
+ * @returns true if the line is an empty statement (non-comment with no content) or a directive
+ */
+export function isEmptyStmt(line: string, document?: vscode.TextDocument): boolean {
+  // Comments are handled separately by isComment(), not here
+  if (isComment(line, document)) {
+    return false;
+  }
+
+  // Directives are treated as empty statements
+  if (isDirective(line)) {
+    return true;
+  }
+
+  // Determine RPG format type if document is provided
+  const isFreeFormat = document ? isFreeFormatRPG(document) : null;
+
+  if (isFreeFormat === true) {
+    // Full free-format RPG IV (**FREE directive)
+    // A statement is empty if the entire line is only whitespace
+    return line.trim() === '';
+  }
+
+  // Fixed format or hybrid free format (respects column 8-80 boundary)
+  // In both cases, the statement content area is columns 8-80
+  // A statement is empty if this area contains only whitespace
+  const statementArea = getCol(line, 8, 80).trim();
+  return statementArea === '';
+}
+
+export function isSkipStmt(line: string, document?: vscode.TextDocument): boolean {
+  const bComment = isComment(line, document);
+  const bEmptyStmt = isEmptyStmt(line, document);
+  const bDirective = isDirective(line);
+  return bComment || bDirective || bEmptyStmt;
+}

--- a/package.json
+++ b/package.json
@@ -116,6 +116,21 @@
 				"category": "RPGLE Fixed-Format",
 				"icon": "$(arrow-right)",
 				"when": "editorLangId == rpgle || editorLangId == rpg"
+			},
+			{
+				"command": "vscode-rpgle.commentStatement",
+				"title": "Comment RPG IV Source Line",
+				"category": "RPGLE"
+			},
+			{
+				"command": "vscode-rpgle.uncommentStatement",
+				"title": "Uncomment RPG IV Source Line",
+				"category": "RPGLE"
+			},
+			{
+				"command": "vscode-rpgle.toggleComment",
+				"title": "Toggle Line Comment",
+				"category": "RPGLE"
 			}
 		],
 		"keybindings": [
@@ -142,9 +157,27 @@
 				"key": "ctrl+]",
 				"mac": "ctrl+]",
 				"when": "editorLangId == rpgle || editorLangId == rpg"
+			},
+			{
+				"command": "vscode-rpgle.toggleComment",
+				"key": "ctrl+/",
+				"mac": "cmd+/",
+				"when": "editorTextFocus && (editorLangId == 'rpg' || editorLangId == 'rpgle' || editorLangId == 'sqlrpgle' || editorLangId == 'rpginc' || editorLangId == 'rpgleinc')"
 			}
 		],
 		"menus": {
+			"editor/context": [
+				{
+					"command": "vscode-rpgle.commentStatement",
+					"when": "resourceExtname =~ /\\.rpg(le)?|\\.sqlrpgle|\\.rpgleinc/i",
+					"group": "vscode-rpgle@1"
+				},
+				{
+					"command": "vscode-rpgle.uncommentStatement",
+					"when": "resourceExtname =~ /\\.rpg(le)?|\\.sqlrpgle|\\.rpgleinc/i",
+					"group": "vscode-rpgle@2"
+				}
+			],
 			"view/item/context": [
 				{
 					"command": "vscode-rpgle.openLintConfig",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
 			},
 			{
 				"command": "vscode-rpgle.toggleComment",
-				"title": "Toggle Line Comment",
+				"title": "Comment (toggle)",
 				"category": "RPGLE"
 			}
 		],
@@ -168,14 +168,9 @@
 		"menus": {
 			"editor/context": [
 				{
-					"command": "vscode-rpgle.commentStatement",
+					"command": "vscode-rpgle.toggleComment",
 					"when": "resourceExtname =~ /\\.rpg(le)?|\\.sqlrpgle|\\.rpgleinc/i",
-					"group": "vscode-rpgle@1"
-				},
-				{
-					"command": "vscode-rpgle.uncommentStatement",
-					"when": "resourceExtname =~ /\\.rpg(le)?|\\.sqlrpgle|\\.rpgleinc/i",
-					"group": "vscode-rpgle@2"
+					"group": "9_cutcopypaste@100"
 				}
 			],
 			"view/item/context": [


### PR DESCRIPTION
Add full RPGIV context aware "Comment/Uncomment" logic. 
- Add Cmd+/ (Mac) / Ctrl+/ (Windows/Linux) keyboard shortcut
- Support both fixed-format and free-format RPG commenting styles
- Add context menu commands for Comment/Uncomment (as alternatives to the keyboard shortcuts)
- Migrated from rpgiv2free extension for consolidation--this feature has been part of rpgiv2free for several months and has been street-tested. It is removed from that extension entirely and is now a part of this extension.
- Handles mixed-format (i.e., auto-detected fixed for free-format source automatically)


### Changes

- Comment-out RPG IV fixed or free format code.
- Uncomment RPG IV fixed or free format code.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
