### PR TITLE
Add missing legacy OPM source type handling after PR 545

### DIFF
--- a/language/parserFactory.ts
+++ b/language/parserFactory.ts
@@ -10,7 +10,7 @@ export type includeFilePromise = (baseFile: string, includeString: string) => Pr
  * Common interface for both parsers
  */
 export interface IParser {
-  getDocs(uri: string, content: string, options?: any): Promise<Cache>;
+  getDocs(uri: string, content: string, options?: any): Promise<Cache | undefined>;
   setTableFetch(promise: tablePromise): void;
   setIncludeFileFetch(promise: includeFilePromise): void;
   clearParsedCache?(path: string): void;
@@ -28,19 +28,35 @@ export class ParserFactory {
    */
   static getParser(uri: string): IParser {
     const extension = uri.toLowerCase().split('.').pop();
-    
+
     if (extension === 'rpg' || extension === 'sqlrpg') {
       return new OpmParser();
     }
-    
+
+    // Deprecated source types
+    if (extension === 'rpg36' || extension === 'rpg38' || extension === 'sqlrpg38') {
+      return new OpmParser();
+    }
+
     // Default to ILE parser for .rpgle, .sqlrpgle, etc.
     return new Parser();
   }
-  
+
   static isOpmFile(uri: string): boolean {
-    return uri.toLowerCase().endsWith('.rpg') || uri.toLowerCase().endsWith('.sqlrpg');
+    const lower = uri.toLowerCase();
+
+    if (lower.endsWith('.rpg') || lower.endsWith('.sqlrpg')) {
+      return true;
+    }
+
+    // Deprecated source types
+    if (lower.endsWith('.rpg36') || lower.endsWith('.rpg38') || lower.endsWith('.sqlrpg38')) {
+      return true;
+    }
+
+    return false;
   }
-  
+
   static isIleFile(uri: string): boolean {
     const lower = uri.toLowerCase();
     return lower.endsWith('.rpgle') || lower.endsWith('.sqlrpgle');

--- a/tests/suite/parserFactory.test.ts
+++ b/tests/suite/parserFactory.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { ParserFactory } from "../../language/parserFactory";
+import Parser from "../../language/ile/parser";
+import { OpmParser } from "../../language/opm/parser";
+
+describe("ParserFactory", () => {
+  it("uses OPM parser for .rpg and .sqlrpg", () => {
+    expect(ParserFactory.getParser("example.rpg")).toBeInstanceOf(OpmParser);
+    expect(ParserFactory.getParser("example.sqlrpg")).toBeInstanceOf(OpmParser);
+    expect(ParserFactory.getParser("EXAMPLE.SQLRPG")).toBeInstanceOf(OpmParser);
+  });
+
+  it("uses OPM parser for deprecated .rpg36, .rpg38, and .sqlrpg38", () => {
+    expect(ParserFactory.getParser("example.rpg36")).toBeInstanceOf(OpmParser);
+    expect(ParserFactory.getParser("example.rpg38")).toBeInstanceOf(OpmParser);
+    expect(ParserFactory.getParser("example.sqlrpg38")).toBeInstanceOf(OpmParser);
+    expect(ParserFactory.getParser("EXAMPLE.RPG38")).toBeInstanceOf(OpmParser);
+  });
+
+  it("uses ILE parser for .rpgle and .sqlrpgle", () => {
+    expect(ParserFactory.getParser("example.rpgle")).toBeInstanceOf(Parser);
+    expect(ParserFactory.getParser("example.sqlrpgle")).toBeInstanceOf(Parser);
+    expect(ParserFactory.getParser("EXAMPLE.SQLRPGLE")).toBeInstanceOf(Parser);
+  });
+
+  it("identifies OPM extensions correctly", () => {
+    expect(ParserFactory.isOpmFile("example.rpg")).toBe(true);
+    expect(ParserFactory.isOpmFile("example.sqlrpg")).toBe(true);
+    expect(ParserFactory.isOpmFile("example.rpg36")).toBe(true);
+    expect(ParserFactory.isOpmFile("example.rpg38")).toBe(true);
+    expect(ParserFactory.isOpmFile("example.sqlrpg38")).toBe(true);
+    expect(ParserFactory.isOpmFile("EXAMPLE.SQLRPG")).toBe(true);
+    expect(ParserFactory.isOpmFile("example.rpgle")).toBe(false);
+  });
+
+  it("identifies ILE extensions correctly", () => {
+    expect(ParserFactory.isIleFile("example.rpgle")).toBe(true);
+    expect(ParserFactory.isIleFile("example.sqlrpgle")).toBe(true);
+    expect(ParserFactory.isIleFile("EXAMPLE.SQLRPGLE")).toBe(true);
+    expect(ParserFactory.isIleFile("example.sqlrpg")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Follow-up to PR #545 to complete legacy OPM source-type routing in ParserFactory.

## What changed
- Route deprecated OPM source types to OPM parser: .rpg36, .rpg38, and .sqlrpg38
- Keep deprecated types in a separate conditional block with a clear comment
- Add focused unit tests for parser routing and extension detection in tests/suite/parserFactory.test.ts
- Align IParser getDocs signature with ILE parser return type (Promise<Cache | undefined>) to fix assignability diagnostics

## Why
PR #545 added OPM/ILE routing but did not include all legacy extensions. This ensures those source members are treated consistently as OPM and prevents regressions with explicit tests.