### PR TITLE
Fix URI extension routing for RPGx and harden column assist behavior

### DIFF
--- a/extension/client/src/language/columnAssist.ts
+++ b/extension/client/src/language/columnAssist.ts
@@ -1,5 +1,6 @@
 
 import { commands, DecorationOptions, ExtensionContext, Range, Selection, TextDocument, ThemeColor, window } from 'vscode';
+import { URI } from 'vscode-uri';
 import * as Configuration from "../configuration";
 import { loadBase } from '../base';
 
@@ -19,6 +20,26 @@ let rulerEnabled = Configuration.get(Configuration.RULER_ENABLED_BY_DEFAULT) || 
 let currentEditorLine = -1;
 
 import { SpecFieldDef, SpecFieldValue, SpecRulers, specs, opmSpecs, opmSpecRulers } from '../schemas/specs';
+
+const ILE_EXTENSIONS: readonly string[] = ['.rpgle', '.sqlrpgle'];
+const OPM_EXTENSIONS: readonly string[] = ['.rpg', '.sqlrpg'];
+const DEPRECATED_OPM_EXTENSIONS: readonly string[] = ['.rpg36', '.rpg38', '.sqlrpg38'];
+
+function getExtension(uri: string): string {
+  const parsed = URI.parse(uri);
+  const dotIndex = parsed.path.lastIndexOf('.');
+  return dotIndex !== -1 ? parsed.path.substring(dotIndex).toLowerCase() : '';
+}
+
+function isOpmFile(uri: string): boolean {
+  const extension = getExtension(uri);
+  return [...OPM_EXTENSIONS, ...DEPRECATED_OPM_EXTENSIONS].includes(extension);
+}
+
+function isIleFile(uri: string): boolean {
+  const extension = getExtension(uri);
+  return ILE_EXTENSIONS.includes(extension);
+}
 
 const getAreasForLine = (line: string, index: number, languageId: string = 'rpgle') => {
   if (line.length < 6) return undefined;
@@ -49,12 +70,12 @@ const getAreasForLine = (line: string, index: number, languageId: string = 'rpgl
 }
 
 function documentIsFree(document: TextDocument) {
-  if (document.languageId === `rpgle`) {
-    const line = document.getText(new Range(0, 0, 0, 6)).toUpperCase();
-    return line === `**FREE`;
-  } else if (document.languageId === `rpg`) {
+  if (isOpmFile(document.uri.toString())) {
     // OPM RPG is always fixed-format
     return false;
+  } else if (isIleFile(document.uri.toString())) {
+    const line = document.getText(new Range(0, 0, 0, 6)).toUpperCase();
+    return line === `**FREE`;
   }
 
   return false;
@@ -67,7 +88,8 @@ export function registerColumnAssist(context: ExtensionContext) {
       if (editor) {
         const document = editor.document;
 
-        if (document.languageId === `rpgle` || document.languageId === `rpg`) {
+        const isOpm = isOpmFile(document.uri.toString());
+        if (isOpm || isIleFile(document.uri.toString())) {
           if (!documentIsFree(document)) {
             const lineNumber = editor.selection.start.line;
             const positionIndex = editor.selection.start.character;
@@ -75,7 +97,7 @@ export function registerColumnAssist(context: ExtensionContext) {
             const positionsData = await promptLine(
               document.getText(new Range(lineNumber, 0, lineNumber, 100)),
               positionIndex,
-              document.languageId
+              isOpm ? 'rpg' : 'rpgle'
             );
 
             if (positionsData) {
@@ -119,15 +141,17 @@ export function registerColumnAssist(context: ExtensionContext) {
 }
 
 function moveFromPosition(direction: "left"|"right", editor = window.activeTextEditor) {
-  if (editor && (editor.document.languageId === `rpgle` || editor.document.languageId === `rpg`) && !documentIsFree(editor.document)) {
+  if (editor && !documentIsFree(editor.document)) {
     const document = editor.document;
+    const isOpm = isOpmFile(document.uri.toString());
+    if (!isOpm && !isIleFile(document.uri.toString())) return;
     const lineNumber = editor.selection.start.line;
     const positionIndex = editor.selection.start.character;
 
     const positionsData = getAreasForLine(
       document.getText(new Range(lineNumber, 0, lineNumber, 100)),
       positionIndex,
-      document.languageId
+      isOpm ? 'rpg' : 'rpgle'
     );
 
     if (positionsData) {
@@ -154,7 +178,8 @@ function updateRuler(editor = window.activeTextEditor) {
 
   if (editor) {
     const document = editor.document;
-    if (document.languageId === `rpgle` || document.languageId === `rpg`) {
+    const isOpm = isOpmFile(document.uri.toString());
+    if (isOpm || isIleFile(document.uri.toString())) {
       if (!documentIsFree(document)) {
         const lineNumber = editor.selection.start.line;
         const positionIndex = editor.selection.start.character;
@@ -162,7 +187,7 @@ function updateRuler(editor = window.activeTextEditor) {
         const positionsData = getAreasForLine(
           document.getText(new Range(lineNumber, 0, lineNumber, 100)),
           positionIndex,
-          document.languageId
+          isOpm ? 'rpg' : 'rpgle'
         );
 
         if (positionsData) {

--- a/extension/client/src/language/columnAssist.ts
+++ b/extension/client/src/language/columnAssist.ts
@@ -1,8 +1,8 @@
 
 import { commands, DecorationOptions, ExtensionContext, Range, Selection, TextDocument, ThemeColor, window } from 'vscode';
-import { URI } from 'vscode-uri';
 import * as Configuration from "../configuration";
 import { loadBase } from '../base';
+import { isIleFileByUri, isOpmFileByUri } from '../../../../language/utils/fileRouting';
 
 const currentArea = window.createTextEditorDecorationType({
   backgroundColor: `rgba(242, 242, 109, 0.3)`,
@@ -21,24 +21,18 @@ let currentEditorLine = -1;
 
 import { SpecFieldDef, SpecFieldValue, SpecRulers, specs, opmSpecs, opmSpecRulers } from '../schemas/specs';
 
-const ILE_EXTENSIONS: readonly string[] = ['.rpgle', '.sqlrpgle'];
-const OPM_EXTENSIONS: readonly string[] = ['.rpg', '.sqlrpg'];
-const DEPRECATED_OPM_EXTENSIONS: readonly string[] = ['.rpg36', '.rpg38', '.sqlrpg38'];
+function documentType(document: TextDocument): 'opm' | 'ile' | undefined {
+  const uri = document.uri.toString();
 
-function getExtension(uri: string): string {
-  const parsed = URI.parse(uri);
-  const dotIndex = parsed.path.lastIndexOf('.');
-  return dotIndex !== -1 ? parsed.path.substring(dotIndex).toLowerCase() : '';
-}
+  if (isOpmFileByUri(uri) || document.languageId === 'rpg') {
+    return 'opm';
+  }
 
-function isOpmFile(uri: string): boolean {
-  const extension = getExtension(uri);
-  return [...OPM_EXTENSIONS, ...DEPRECATED_OPM_EXTENSIONS].includes(extension);
-}
+  if (isIleFileByUri(uri) || document.languageId === 'rpgle') {
+    return 'ile';
+  }
 
-function isIleFile(uri: string): boolean {
-  const extension = getExtension(uri);
-  return ILE_EXTENSIONS.includes(extension);
+  return undefined;
 }
 
 const getAreasForLine = (line: string, index: number, languageId: string = 'rpgle') => {
@@ -70,10 +64,12 @@ const getAreasForLine = (line: string, index: number, languageId: string = 'rpgl
 }
 
 function documentIsFree(document: TextDocument) {
-  if (isOpmFile(document.uri.toString())) {
+  const type = documentType(document);
+
+  if (type === 'opm') {
     // OPM RPG is always fixed-format
     return false;
-  } else if (isIleFile(document.uri.toString())) {
+  } else if (type === 'ile') {
     const line = document.getText(new Range(0, 0, 0, 6)).toUpperCase();
     return line === `**FREE`;
   }
@@ -88,8 +84,8 @@ export function registerColumnAssist(context: ExtensionContext) {
       if (editor) {
         const document = editor.document;
 
-        const isOpm = isOpmFile(document.uri.toString());
-        if (isOpm || isIleFile(document.uri.toString())) {
+        const type = documentType(document);
+        if (type) {
           if (!documentIsFree(document)) {
             const lineNumber = editor.selection.start.line;
             const positionIndex = editor.selection.start.character;
@@ -97,7 +93,7 @@ export function registerColumnAssist(context: ExtensionContext) {
             const positionsData = await promptLine(
               document.getText(new Range(lineNumber, 0, lineNumber, 100)),
               positionIndex,
-              isOpm ? 'rpg' : 'rpgle'
+              type === 'opm' ? 'rpg' : 'rpgle'
             );
 
             if (positionsData) {
@@ -143,15 +139,15 @@ export function registerColumnAssist(context: ExtensionContext) {
 function moveFromPosition(direction: "left"|"right", editor = window.activeTextEditor) {
   if (editor && !documentIsFree(editor.document)) {
     const document = editor.document;
-    const isOpm = isOpmFile(document.uri.toString());
-    if (!isOpm && !isIleFile(document.uri.toString())) return;
+    const type = documentType(document);
+    if (!type) return;
     const lineNumber = editor.selection.start.line;
     const positionIndex = editor.selection.start.character;
 
     const positionsData = getAreasForLine(
       document.getText(new Range(lineNumber, 0, lineNumber, 100)),
       positionIndex,
-      isOpm ? 'rpg' : 'rpgle'
+      type === 'opm' ? 'rpg' : 'rpgle'
     );
 
     if (positionsData) {
@@ -178,8 +174,8 @@ function updateRuler(editor = window.activeTextEditor) {
 
   if (editor) {
     const document = editor.document;
-    const isOpm = isOpmFile(document.uri.toString());
-    if (isOpm || isIleFile(document.uri.toString())) {
+    const type = documentType(document);
+    if (type) {
       if (!documentIsFree(document)) {
         const lineNumber = editor.selection.start.line;
         const positionIndex = editor.selection.start.character;
@@ -187,7 +183,7 @@ function updateRuler(editor = window.activeTextEditor) {
         const positionsData = getAreasForLine(
           document.getText(new Range(lineNumber, 0, lineNumber, 100)),
           positionIndex,
-          isOpm ? 'rpg' : 'rpgle'
+          type === 'opm' ? 'rpg' : 'rpgle'
         );
 
         if (positionsData) {

--- a/language/parserFactory.ts
+++ b/language/parserFactory.ts
@@ -3,9 +3,6 @@ import Parser from './ile/parser';
 import Cache from './models/cache';
 import Declaration from './models/declaration';
 import {
-  ILE_EXTENSIONS,
-  OPM_EXTENSIONS,
-  DEPRECATED_OPM_EXTENSIONS,
   isIleFileByUri,
   isOpmFileByUri,
 } from './utils/fileRouting';
@@ -28,10 +25,6 @@ export interface IParser {
  * Factory to get appropriate parser based on file extension
  */
 export class ParserFactory {
-  static ILE_EXTENSIONS = ILE_EXTENSIONS;
-  static OPM_EXTENSIONS = OPM_EXTENSIONS;
-  static DEPRECATED_OPM_EXTENSIONS = DEPRECATED_OPM_EXTENSIONS;
-
   static getParser(uri: string): IParser {
     if (ParserFactory.isOpmFile(uri)) {
       return new OpmParser();

--- a/language/parserFactory.ts
+++ b/language/parserFactory.ts
@@ -26,8 +26,18 @@ export class ParserFactory {
    * .rpg → OPM Parser
    * .rpgle, .sqlrpgle → ILE Parser
    */
+  /**
+   * Extract the file extension from a URI, stripping any query string or fragment first.
+   * e.g. "file.rpgle?readonly%3Dfalse" → "rpgle"
+   */
+  private static getExtension(uri: string): string {
+    const path = uri.split('?')[0];
+    const dotIndex = path.lastIndexOf('.');
+    return dotIndex !== -1 ? path.substring(dotIndex + 1).toLowerCase() : '';
+  }
+
   static getParser(uri: string): IParser {
-    const extension = uri.toLowerCase().split('.').pop();
+    const extension = ParserFactory.getExtension(uri);
 
     if (extension === 'rpg' || extension === 'sqlrpg') {
       return new OpmParser();
@@ -43,14 +53,14 @@ export class ParserFactory {
   }
 
   static isOpmFile(uri: string): boolean {
-    const lower = uri.toLowerCase();
+    const extension = ParserFactory.getExtension(uri);
 
-    if (lower.endsWith('.rpg') || lower.endsWith('.sqlrpg')) {
+    if (extension === 'rpg' || extension === 'sqlrpg') {
       return true;
     }
 
     // Deprecated source types
-    if (lower.endsWith('.rpg36') || lower.endsWith('.rpg38') || lower.endsWith('.sqlrpg38')) {
+    if (extension === 'rpg36' || extension === 'rpg38' || extension === 'sqlrpg38') {
       return true;
     }
 
@@ -58,7 +68,7 @@ export class ParserFactory {
   }
 
   static isIleFile(uri: string): boolean {
-    const lower = uri.toLowerCase();
-    return lower.endsWith('.rpgle') || lower.endsWith('.sqlrpgle');
+    const extension = ParserFactory.getExtension(uri);
+    return extension === 'rpgle' || extension === 'sqlrpgle';
   }
 }

--- a/language/parserFactory.ts
+++ b/language/parserFactory.ts
@@ -1,3 +1,5 @@
+import { URI } from 'vscode-uri';
+import * as path from 'path';
 import { OpmParser } from './opm/parser';
 import Parser from './ile/parser';
 import Cache from './models/cache';
@@ -17,34 +19,35 @@ export interface IParser {
   clearTableCache?(): void;
 }
 
+export const ILE_EXTENSIONS: readonly string[] = ['.rpgle', '.sqlrpgle'];
+export const OPM_EXTENSIONS: readonly string[] = ['.rpg', '.sqlrpg'];
+export const DEPRECATED_OPM_EXTENSIONS: readonly string[] = ['.rpg36', '.rpg38', '.sqlrpg38'];
+
 /**
  * Factory to get appropriate parser based on file extension
  */
 export class ParserFactory {
+  static ILE_EXTENSIONS = ILE_EXTENSIONS;
+  static OPM_EXTENSIONS = OPM_EXTENSIONS;
+  static DEPRECATED_OPM_EXTENSIONS = DEPRECATED_OPM_EXTENSIONS;
+
   /**
    * Get parser for file based on extension
    * .rpg → OPM Parser
    * .rpgle, .sqlrpgle → ILE Parser
    */
   /**
-   * Extract the file extension from a URI, stripping any query string or fragment first.
-   * e.g. "file.rpgle?readonly%3Dfalse" → "rpgle"
+   * Extract the file extension from a URI using vscode-uri to correctly
+   * handle query strings, fragments, and encoding.
+   * e.g. "file.rpgle?readonly%3Dfalse" → ".rpgle"
    */
   private static getExtension(uri: string): string {
-    const path = uri.split('?')[0];
-    const dotIndex = path.lastIndexOf('.');
-    return dotIndex !== -1 ? path.substring(dotIndex + 1).toLowerCase() : '';
+    const parsed = URI.parse(uri);
+    return path.extname(parsed.path).toLowerCase();
   }
 
   static getParser(uri: string): IParser {
-    const extension = ParserFactory.getExtension(uri);
-
-    if (extension === 'rpg' || extension === 'sqlrpg') {
-      return new OpmParser();
-    }
-
-    // Deprecated source types
-    if (extension === 'rpg36' || extension === 'rpg38' || extension === 'sqlrpg38') {
+    if (ParserFactory.isOpmFile(uri)) {
       return new OpmParser();
     }
 
@@ -54,21 +57,11 @@ export class ParserFactory {
 
   static isOpmFile(uri: string): boolean {
     const extension = ParserFactory.getExtension(uri);
-
-    if (extension === 'rpg' || extension === 'sqlrpg') {
-      return true;
-    }
-
-    // Deprecated source types
-    if (extension === 'rpg36' || extension === 'rpg38' || extension === 'sqlrpg38') {
-      return true;
-    }
-
-    return false;
+    return [...ParserFactory.OPM_EXTENSIONS, ...ParserFactory.DEPRECATED_OPM_EXTENSIONS].includes(extension);
   }
 
   static isIleFile(uri: string): boolean {
     const extension = ParserFactory.getExtension(uri);
-    return extension === 'rpgle' || extension === 'sqlrpgle';
+    return ParserFactory.ILE_EXTENSIONS.includes(extension);
   }
 }

--- a/language/parserFactory.ts
+++ b/language/parserFactory.ts
@@ -1,9 +1,14 @@
-import { URI } from 'vscode-uri';
-import * as path from 'path';
 import { OpmParser } from './opm/parser';
 import Parser from './ile/parser';
 import Cache from './models/cache';
 import Declaration from './models/declaration';
+import {
+  ILE_EXTENSIONS,
+  OPM_EXTENSIONS,
+  DEPRECATED_OPM_EXTENSIONS,
+  isIleFileByUri,
+  isOpmFileByUri,
+} from './utils/fileRouting';
 
 export type tablePromise = (name: string, aliases?: boolean) => Promise<Declaration[]>;
 export type includeFilePromise = (baseFile: string, includeString: string) => Promise<{found: boolean, uri?: string, content?: string}>;
@@ -19,10 +24,6 @@ export interface IParser {
   clearTableCache?(): void;
 }
 
-export const ILE_EXTENSIONS: readonly string[] = ['.rpgle', '.sqlrpgle'];
-export const OPM_EXTENSIONS: readonly string[] = ['.rpg', '.sqlrpg'];
-export const DEPRECATED_OPM_EXTENSIONS: readonly string[] = ['.rpg36', '.rpg38', '.sqlrpg38'];
-
 /**
  * Factory to get appropriate parser based on file extension
  */
@@ -30,21 +31,6 @@ export class ParserFactory {
   static ILE_EXTENSIONS = ILE_EXTENSIONS;
   static OPM_EXTENSIONS = OPM_EXTENSIONS;
   static DEPRECATED_OPM_EXTENSIONS = DEPRECATED_OPM_EXTENSIONS;
-
-  /**
-   * Get parser for file based on extension
-   * .rpg → OPM Parser
-   * .rpgle, .sqlrpgle → ILE Parser
-   */
-  /**
-   * Extract the file extension from a URI using vscode-uri to correctly
-   * handle query strings, fragments, and encoding.
-   * e.g. "file.rpgle?readonly%3Dfalse" → ".rpgle"
-   */
-  private static getExtension(uri: string): string {
-    const parsed = URI.parse(uri);
-    return path.extname(parsed.path).toLowerCase();
-  }
 
   static getParser(uri: string): IParser {
     if (ParserFactory.isOpmFile(uri)) {
@@ -56,12 +42,10 @@ export class ParserFactory {
   }
 
   static isOpmFile(uri: string): boolean {
-    const extension = ParserFactory.getExtension(uri);
-    return [...ParserFactory.OPM_EXTENSIONS, ...ParserFactory.DEPRECATED_OPM_EXTENSIONS].includes(extension);
+    return isOpmFileByUri(uri);
   }
 
   static isIleFile(uri: string): boolean {
-    const extension = ParserFactory.getExtension(uri);
-    return ParserFactory.ILE_EXTENSIONS.includes(extension);
+    return isIleFileByUri(uri);
   }
 }

--- a/language/utils/fileRouting.ts
+++ b/language/utils/fileRouting.ts
@@ -1,0 +1,21 @@
+import { URI } from 'vscode-uri';
+import * as path from 'path';
+
+export const ILE_EXTENSIONS: readonly string[] = ['.rpgle', '.sqlrpgle'];
+export const OPM_EXTENSIONS: readonly string[] = ['.rpg', '.sqlrpg'];
+export const DEPRECATED_OPM_EXTENSIONS: readonly string[] = ['.rpg36', '.rpg38', '.sqlrpg38'];
+
+export function getExtensionFromUri(uri: string): string {
+  const parsed = URI.parse(uri);
+  return path.extname(parsed.path).toLowerCase();
+}
+
+export function isOpmFileByUri(uri: string): boolean {
+  const extension = getExtensionFromUri(uri);
+  return [...OPM_EXTENSIONS, ...DEPRECATED_OPM_EXTENSIONS].includes(extension);
+}
+
+export function isIleFileByUri(uri: string): boolean {
+  const extension = getExtensionFromUri(uri);
+  return ILE_EXTENSIONS.includes(extension);
+}

--- a/tests/suite/parserFactory.test.ts
+++ b/tests/suite/parserFactory.test.ts
@@ -39,4 +39,43 @@ describe("ParserFactory", () => {
     expect(ParserFactory.isIleFile("EXAMPLE.SQLRPGLE")).toBe(true);
     expect(ParserFactory.isIleFile("example.sqlrpg")).toBe(false);
   });
+
+  it("handles URI query strings and fragments consistently", () => {
+    expect(ParserFactory.isOpmFile("file:///tmp/ORDENT.rpg38?readonly%3Dfalse")).toBe(true);
+    expect(ParserFactory.isOpmFile("file:///tmp/ORDENT.sqlrpg#section-a")).toBe(true);
+    expect(ParserFactory.isIleFile("file:///tmp/ORDENT.sqlrpgle?x=1#y")).toBe(true);
+
+    expect(ParserFactory.getParser("file:///tmp/ORDENT.rpg38?readonly%3Dfalse")).toBeInstanceOf(OpmParser);
+    expect(ParserFactory.getParser("file:///tmp/ORDENT.sqlrpgle?x=1#y")).toBeInstanceOf(Parser);
+  });
+
+  it("is order-independent when opening mixed RPG file types", () => {
+    const openedUris = [
+      "file:///tmp/one.rpgle",
+      "file:///tmp/two.rpg",
+      "file:///tmp/three.rpg38",
+      "file:///tmp/four.sqlrpg",
+      "file:///tmp/five.sqlrpgle",
+      "file:///tmp/six.sqlrpg38?readonly%3Dfalse"
+    ];
+
+    // Simulate different open order to ensure routing never depends on previously opened files.
+    const sequences = [
+      openedUris,
+      [...openedUris].reverse(),
+      [openedUris[2], openedUris[0], openedUris[5], openedUris[1], openedUris[4], openedUris[3]]
+    ];
+
+    sequences.forEach(sequence => {
+      sequence.forEach(uri => {
+        if (uri.includes(".rpgle") || uri.includes(".sqlrpgle")) {
+          expect(ParserFactory.getParser(uri)).toBeInstanceOf(Parser);
+          expect(ParserFactory.isIleFile(uri)).toBe(true);
+        } else {
+          expect(ParserFactory.getParser(uri)).toBeInstanceOf(OpmParser);
+          expect(ParserFactory.isOpmFile(uri)).toBe(true);
+        }
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary\n- route OPM/ILE selection by URI extension (including deprecated OPM extensions)\n- keep extension parsing URI-aware for query/fragment-safe classification\n- add regression tests for URI query/fragment handling and mixed file-open order\n\n## Why\nThis supersedes #549 and includes its extension-detection improvements plus hardening for mixed RPGx open patterns.\n\n## Validation\n- npx vitest run tests/suite/parserFactory.test.ts\n