### PR TITLE
Fix false unmatched ENDIF/ENDSR after fixed-format embedded SQL

### DIFF
--- a/language/utils/sqlDetection.ts
+++ b/language/utils/sqlDetection.ts
@@ -9,75 +9,129 @@
  * @returns true if the position is inside a SQL block
  */
 export function isInSqlBlock(text: string, offset: number): boolean {
-  // Find the line containing the offset
-  let lineStart = offset;
-  while (lineStart > 0 && text[lineStart - 1] !== '\n' && text[lineStart - 1] !== '\r') {
-    lineStart--;
-  }
-  
-  // Check if this line starts with EXEC SQL (ignoring whitespace)
-  const currentLine = text.substring(lineStart, offset);
-  if (/^\s*exec\s+sql\b/i.test(currentLine)) {
-    // We're on a line that starts with EXEC SQL, so we're in SQL
-    return true;
-  }
-  
-  // Look backwards for EXEC SQL
-  const textBeforeOffset = text.substring(0, offset);
-  
-  // Find all SQL block starts and ends
-  const execSqlRegex = /\b(exec\s+sql)\b/gi;
-  
-  let lastExecSql = -1;
-  let lastExecSqlEnd = -1;
-  
-  // Find last EXEC SQL before current position
-  let match;
-  execSqlRegex.lastIndex = 0;
-  while ((match = execSqlRegex.exec(textBeforeOffset)) !== null) {
-    // Check if this EXEC SQL is inside a comment or string
-    if (!isInCommentOrString(text, match.index)) {
-      lastExecSql = match.index;
-      lastExecSqlEnd = match.index + match[0].length;
-    }
-  }
-  
-  // If we found an EXEC SQL, check if there's a semicolon after it (before current position)
-  if (lastExecSql !== -1) {
-    const textAfterExec = text.substring(lastExecSqlEnd, offset);
-    
-    // Look for semicolon that ends the SQL block
-    // We need to be careful not to match semicolons inside SQL strings
-    let inString = false;
-    let stringChar = '';
-    
-    for (let i = 0; i < textAfterExec.length; i++) {
-      const char = textAfterExec[i];
-      
-      // Handle string delimiters (both single and double quotes in SQL)
-      if ((char === "'" || char === '"') && !inString) {
-        inString = true;
-        stringChar = char;
-      } else if (char === stringChar && inString) {
-        // Check for escaped quotes (doubled quotes in SQL)
-        if (i + 1 < textAfterExec.length && textAfterExec[i + 1] === stringChar) {
-          i++; // Skip the escaped quote
-        } else {
-          inString = false;
-          stringChar = '';
+  // Normalize offset so partial-line checks are safe.
+  const safeOffset = Math.max(0, Math.min(offset, text.length));
+
+  // Track whether we are currently inside an SQL block while scanning
+  // from the start of the source up to the target offset.
+  let inSql = false;
+  let sqlMode: 'free' | 'fixed' | undefined;
+
+  // Keep SQL string state for free-form EXEC SQL blocks so semicolons inside
+  // SQL literals do not terminate the block.
+  let inSqlString = false;
+  let sqlStringChar = '';
+
+  // Fixed-format SQL accepts C/ in column 6 (often with sequence numbers in
+  // columns 1-5), but we also allow leading-whitespace-only variants.
+  const fixedExecRegex = /^(?:.{5}[cC]\/\s*exec\s+sql\b|\s*[cC]\/\s*exec\s+sql\b)/i;
+  const fixedEndExecRegex = /^(?:.{5}[cC]\/\s*end-?exec\b|\s*[cC]\/\s*end-?exec\b)/i;
+  const freeExecRegex = /^\s*exec\s+sql\b/i;
+
+  let lineStart = 0;
+  while (lineStart <= safeOffset) {
+    let lineEnd = text.indexOf('\n', lineStart);
+    if (lineEnd === -1) lineEnd = text.length;
+
+    const fullLine = text.substring(lineStart, lineEnd).replace(/\r$/, '');
+    const isTargetLine = safeOffset <= lineEnd;
+    const targetColumn = Math.max(0, safeOffset - lineStart);
+    const lineToProcess = isTargetLine ? fullLine.substring(0, targetColumn) : fullLine;
+
+    if (!inSql) {
+      const fixedExecMatch = lineToProcess.match(fixedExecRegex);
+      if (fixedExecMatch) {
+        const startIndex = lineStart + fixedExecMatch.index;
+        if (!isInCommentOrString(text, startIndex)) {
+          inSql = true;
+          sqlMode = 'fixed';
+        }
+      } else {
+        const freeExecMatch = lineToProcess.match(freeExecRegex);
+        if (freeExecMatch) {
+          const startIndex = lineStart + freeExecMatch.index;
+          if (!isInCommentOrString(text, startIndex)) {
+            inSql = true;
+            sqlMode = 'free';
+
+            const afterExec = lineToProcess.substring((freeExecMatch.index || 0) + freeExecMatch[0].length);
+            if (scanForSqlTerminator(afterExec, (state) => {
+              inSqlString = state.inString;
+              sqlStringChar = state.stringChar;
+            }, inSqlString, sqlStringChar)) {
+              inSql = false;
+              sqlMode = undefined;
+              inSqlString = false;
+              sqlStringChar = '';
+            }
+          }
         }
       }
-      
-      // If we find a semicolon outside of a string, the SQL block has ended
-      if (char === ';' && !inString) {
-        return false;
+    } else if (sqlMode === 'fixed') {
+      const fixedEndMatch = lineToProcess.match(fixedEndExecRegex);
+      if (fixedEndMatch) {
+        const endIndex = lineStart + fixedEndMatch.index;
+        if (!isInCommentOrString(text, endIndex)) {
+          inSql = false;
+          sqlMode = undefined;
+          inSqlString = false;
+          sqlStringChar = '';
+        }
+      }
+    } else if (sqlMode === 'free') {
+      if (scanForSqlTerminator(lineToProcess, (state) => {
+        inSqlString = state.inString;
+        sqlStringChar = state.stringChar;
+      }, inSqlString, sqlStringChar)) {
+        inSql = false;
+        sqlMode = undefined;
+        inSqlString = false;
+        sqlStringChar = '';
       }
     }
-    
-    // No semicolon found, we're still in the SQL block
-    return true;
+
+    if (isTargetLine || lineEnd === text.length) {
+      break;
+    }
+
+    lineStart = lineEnd + 1;
   }
-  
+
+  return inSql;
+}
+
+function scanForSqlTerminator(
+  source: string,
+  updateState: (state: { inString: boolean; stringChar: string }) => void,
+  initialInString = false,
+  initialStringChar = ''
+): boolean {
+  let inString = initialInString;
+  let stringChar = initialStringChar;
+
+  for (let i = 0; i < source.length; i++) {
+    const char = source[i];
+
+    if ((char === "'" || char === '"') && !inString) {
+      inString = true;
+      stringChar = char;
+    } else if (char === stringChar && inString) {
+      // SQL escaped quotes are doubled.
+      if (i + 1 < source.length && source[i + 1] === stringChar) {
+        i++;
+      } else {
+        inString = false;
+        stringChar = '';
+      }
+    }
+
+    if (char === ';' && !inString) {
+      updateState({ inString, stringChar });
+      return true;
+    }
+  }
+
+  updateState({ inString, stringChar });
   return false;
 }
 
@@ -93,16 +147,16 @@ export function isInCommentOrString(text: string, offset: number): boolean {
   while (lineStart > 0 && text[lineStart - 1] !== '\n' && text[lineStart - 1] !== '\r') {
     lineStart--;
   }
-  
+
   // Extract line content before the offset
   const lineBeforeOffset = text.substring(lineStart, offset);
-  
+
   // Check if there's a comment marker before this position
   const commentIndex = lineBeforeOffset.indexOf('//');
   if (commentIndex !== -1) {
     return true;
   }
-  
+
   // Check if the offset is inside a string delimited by single quotes
   let inString = false;
   for (let i = 0; i < lineBeforeOffset.length; i++) {
@@ -110,10 +164,10 @@ export function isInCommentOrString(text: string, offset: number): boolean {
       inString = !inString;
     }
   }
-  
+
   if (inString) {
     return true;
   }
-  
+
   return false;
 }

--- a/tests/suite/blockParser.test.ts
+++ b/tests/suite/blockParser.test.ts
@@ -77,7 +77,7 @@ endif;`;
     it('should skip SELECT in SQL blocks', () => {
       const code = `exec sql
   select * from table;
-  
+
 if x > 0;
   y = 1;
 endif;`;
@@ -98,6 +98,25 @@ endsl;`;
       expect(matches).to.have.lengthOf(2);
       expect(matches[0].word).to.equal('select');
       expect(matches[1].word).to.equal('endsl');
+    });
+
+    it('should not treat ENDIF and ENDSR after fixed-format SQL as SQL content', () => {
+      const code = `00001C/EXEC SQL
+00002C+ Set Option COMMIT = *NONE
+00003C/END-EXEC
+
+00004CSR   ELAB          BEGSR
+00005C                   IF        IDARIF <> ''
+00006C                   ENDIF
+00007C                   ENDSR`;
+
+      const matches = findAllBlockMatches(code, isInCommentOrString, isInSqlBlock);
+      const words = matches.map(match => match.word);
+
+      expect(words).to.include('begsr');
+      expect(words).to.include('if');
+      expect(words).to.include('endif');
+      expect(words).to.include('endsr');
     });
 
     it('should find FOR-EACH blocks', () => {

--- a/tests/suite/sqlDetection.test.ts
+++ b/tests/suite/sqlDetection.test.ts
@@ -21,7 +21,7 @@ describe('sqlDetection', () => {
     it('should not detect position after SQL block ends', () => {
       const code = `exec sql
   select * from table;
-  
+
 if x > 0;
   y = 1;
 endif;`;
@@ -53,7 +53,7 @@ endif;`;
       const offset1 = code.indexOf('table1');
       const offset2 = code.indexOf('if x');
       const offset3 = code.indexOf('table2');
-      
+
       expect(isInSqlBlock(code, offset1)).to.be.true;
       expect(isInSqlBlock(code, offset2)).to.be.false;
       expect(isInSqlBlock(code, offset3)).to.be.true;
@@ -70,6 +70,57 @@ endif;`;
       const code = `EXEC SQL SELECT * FROM TABLE;`;
       const offset = code.indexOf('SELECT');
       expect(isInSqlBlock(code, offset)).to.be.true;
+    });
+
+    it('should detect position in fixed-format C/EXEC SQL block', () => {
+      const code = `     C/EXEC SQL
+     C+ Set Option COMMIT = *NONE
+     C/END-EXEC
+     C                   IF        FLAG <> ''
+     C                   ENDIF`;
+      const sqlOffset = code.indexOf('Option');
+      expect(isInSqlBlock(code, sqlOffset)).to.be.true;
+    });
+
+    it('should not detect position after fixed-format C/END-EXEC', () => {
+      const code = `     C/EXEC SQL
+     C+ Set Option COMMIT = *NONE
+     C/END-EXEC
+     C                   IF        FLAG <> ''
+     C                   ENDIF`;
+      const ifOffset = code.indexOf('IF        FLAG');
+      expect(isInSqlBlock(code, ifOffset)).to.be.false;
+    });
+
+    it('should not keep fixed SQL mode active for following fixed-form code', () => {
+      const code = `     C/EXEC SQL
+     C+ Set Option COMMIT = *NONE
+     C/END-EXEC
+
+     CSR   ELAB          BEGSR
+     C                   IF        IDARIF <> ''
+     C                   ENDIF
+     C                   ENDSR`;
+
+      const begsrOffset = code.indexOf('BEGSR');
+      const endifOffset = code.indexOf('ENDIF');
+
+      expect(isInSqlBlock(code, begsrOffset)).to.be.false;
+      expect(isInSqlBlock(code, endifOffset)).to.be.false;
+    });
+
+    it('should detect fixed-format SQL with column-6 C markers and sequence prefixes', () => {
+      const code = `00001C/EXEC SQL
+00002C+ Set Option COMMIT = *NONE
+00003C/END-EXEC
+00004C                   IF        FLAG <> ''
+00005C                   ENDIF`;
+
+      const sqlOffset = code.indexOf('Option');
+      const ifOffset = code.indexOf('IF        FLAG');
+
+      expect(isInSqlBlock(code, sqlOffset)).to.be.true;
+      expect(isInSqlBlock(code, ifOffset)).to.be.false;
     });
   });
 
@@ -103,7 +154,7 @@ endif;`;
       const offset1 = code.indexOf('hello');
       const offset2 = code.indexOf('+');
       const offset3 = code.indexOf('world');
-      
+
       expect(isInCommentOrString(code, offset1)).to.be.true;
       expect(isInCommentOrString(code, offset2)).to.be.false;
       expect(isInCommentOrString(code, offset3)).to.be.true;
@@ -119,7 +170,7 @@ endif;`;
       const code = `msg = 'hello'; // comment`;
       const offset1 = code.indexOf('hello');
       const offset2 = code.indexOf('comment');
-      
+
       expect(isInCommentOrString(code, offset1)).to.be.true;
       expect(isInCommentOrString(code, offset2)).to.be.true;
     });
@@ -155,10 +206,10 @@ select;
   when x = 1;
     y = 1;
 endsl;`;
-      
+
       const sqlSelectOffset = code.indexOf('select *');
       const rpgleSelectOffset = code.indexOf('select;');
-      
+
       expect(isInSqlBlock(code, sqlSelectOffset)).to.be.true;
       expect(isInSqlBlock(code, rpgleSelectOffset)).to.be.false;
     });
@@ -168,10 +219,10 @@ endsl;`;
 if x > 0;
   y = 1;
 endif;`;
-      
+
       const commentedSqlOffset = code.indexOf('select');
       const ifOffset = code.indexOf('if x');
-      
+
       expect(isInCommentOrString(code, commentedSqlOffset)).to.be.true;
       expect(isInCommentOrString(code, ifOffset)).to.be.false;
     });
@@ -179,7 +230,7 @@ endif;`;
     it('should handle SQL in string literal', () => {
       const code = `msg = 'exec sql select * from table';`;
       const offset = code.indexOf('select');
-      
+
       expect(isInCommentOrString(code, offset)).to.be.true;
       expect(isInSqlBlock(code, offset)).to.be.false;
     });


### PR DESCRIPTION
## Summary
- fix SQL block detection to support both free-format `EXEC SQL ... ;` and fixed-format `C/EXEC SQL ... C/END-EXEC`
- support fixed-format column-6 `C/` delimiters including sequence-number-prefixed lines (for example `00001C/EXEC SQL`)
- prevent SQL mode from leaking into subsequent fixed-format RPG statements, which caused false unmatched highlighting on `ENDIF` and `ENDSR`
- add regression tests in SQL detection and block parser suites

## Validation
- npm test -- tests/suite/sqlDetection.test.ts tests/suite/blockParser.test.ts
- 39 tests passed
