### PR TITLE
Add missing tsconfig files for compile script wiring

### DIFF
--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "outDir": "out",
+    "rootDir": "..",
+    "lib": ["es2020"],
+    "allowJs": true,
+    "strict": false,
+    "noImplicitAny": false,
+    "noUnusedParameters": false,
+    "composite": true
+  },
+  "include": [
+    "./**/*.ts",
+    "../language/**/*.ts",
+    "../extension/server/src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    ".vscode-test"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./extension/client/tsconfig.json" },
+    { "path": "./extension/server/tsconfig.json" },
+    { "path": "./tests/tsconfig.json" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add missing root `tsconfig.json` for TypeScript build mode
- add missing `tests/tsconfig.json` referenced by existing npm scripts

## Why
- `npm run compile` previously failed immediately because root `tsconfig.json` was missing
- `npm run compile:tests` previously failed immediately because `tests/tsconfig.json` was missing

## Notes
- this PR fixes build wiring/config discovery only
- it does not attempt to resolve the existing TypeScript strict/type errors in parser and dependency type packages

