### PR TITLE
Fix outline DS

### DIFF
--- a/extension/server/src/providers/documentSymbols.ts
+++ b/extension/server/src/providers/documentSymbols.ts
@@ -63,9 +63,6 @@ export default async function documentSymbolProvider(handler: DocumentSymbolPara
 			{ pattern: /\b(for|for-each)\s+(.+?)(?:;|$)/gi, kind: SymbolKind.Null },
 			{ pattern: /\b(select)\b/gi, kind: SymbolKind.Null },
 			{ pattern: /\b(monitor)\b/gi, kind: SymbolKind.Null },
-			{ pattern: /\b(dcl-ds)\s+(\w+)/gi, kind: SymbolKind.Struct },
-			{ pattern: /\b(dcl-pi)\s+(\w+)/gi, kind: SymbolKind.Interface },
-			{ pattern: /\b(dcl-enum)\s+(\w+)/gi, kind: SymbolKind.Enum },
 			{ pattern: /\b(casxx|caseq|casne|casgt|caslt|casge|casle)\s+(.+?)(?:;|$)/gi, kind: SymbolKind.Null },
 		];
 


### PR DESCRIPTION
### Changes

Removed the dcl-ds, dcl-pi and dcl-enum patterns from blockPatterns in getCodeBlockSymbols, since that regex pass only needs to cover control-flow blocks (IF, DOW, FOR, SELECT, MONITOR).

### How to test it?
Copy program by @richardm90 in issue #564, now the outline should be ok.

<img width="454" height="470" alt="image" src="https://github.com/user-attachments/assets/e35488c3-1269-4378-910b-1b3d119201f8" />


### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [x] have added myself to the contributors' list in the README

Closes #564 