### PR TITLE
fix(columnAssist): skip ruler for fixed-format SQL continuation lines (col 7 = '+')

### DIFF
--- a/extension/client/src/language/columnAssist.ts
+++ b/extension/client/src/language/columnAssist.ts
@@ -167,7 +167,10 @@ function getCalculationRulerKey(line: string): 'C' | 'CX' {
 
 const getAreasForLine = (line: string, index: number, languageId: string = 'rpgle') => {
     if (line.length < 6) return undefined;
-    if (line[6] === `*` || line[6] === `/`) return undefined;
+    // Skip comments (*), compiler directives (/), and legacy embedded SQL
+    // continuation lines (+). A `+` in column 7 marks a C-spec SQL continuation
+    // line (e.g. `.....C+ FROM qiws.qcustcdt;`) and must never trigger the ruler.
+    if (line[6] === `*` || line[6] === `/` || line[6] === `+`) return undefined;
 
     const specDefinitions = languageId === 'rpg' ? opmSpecs : specs;
     const rulerDefinitions = languageId === 'rpg' ? opmSpecRulers : SpecRulers;


### PR DESCRIPTION
## Summary

Extends the spec-ruler guard in `getAreasForLine` to skip lines where column 7 (index 6) is `+`.

A `+` in column 7 marks a legacy fixed-format C-spec SQL continuation line (e.g. `.....C+ FROM qiws.qcustcdt;`). The existing guard already skipped `*` (comment lines) and `/` (compiler directives) but not `+`, so the C-spec ruler was incorrectly painted on SQL continuation lines.

## Change

```ts
// before
if (line[6] === `*` || line[6] === `/`) return undefined;

// after
if (line[6] === `*` || line[6] === `/` || line[6] === `+`) return undefined;
```

No additional free-format check is needed: both callers of `getAreasForLine` (`updateRuler` and `moveFromPosition`) are already gated by `!documentIsFree(document)`, so this function is only ever reached on fixed-format source.

Closes #495 (supersedes that PR for this specific item; the other two items in #495 were addressed by the ruler rewrite in #559).