### PR TITLE
fix(bracketMatcher): string continuation in quoted literals + CASxx compound block highlighting

### DIFF
--- a/extension/client/src/language/bracketMatcher.ts
+++ b/extension/client/src/language/bracketMatcher.ts
@@ -1060,9 +1060,20 @@ function findBlockIndices(
   let closeIndex = -1;
 
   if (isOpen) {
-    // If opening, find matching close
-    openIndex = currentIndex;
-    closeIndex = findMatchingClose(text, matches, currentIndex, pair);
+    if (pair.nonNestable) {
+      // Non-nestable compound block: scan backward to find the first opener in the run
+      openIndex = currentIndex;
+      for (let i = currentIndex - 1; i >= 0; i--) {
+        if (pair.open.includes(matches[i].word)) {
+          openIndex = i;
+        } else {
+          break;
+        }
+      }
+    } else {
+      openIndex = currentIndex;
+    }
+    closeIndex = findMatchingClose(text, matches, openIndex, pair);
   } else if (isClose) {
     // If closing, find matching open
     closeIndex = currentIndex;
@@ -1079,6 +1090,15 @@ function findBlockIndices(
 
   // Collect all block indices (open, close, and same-level middle keywords)
   const blockIndices: number[] = [openIndex, closeIndex];
+
+  // Non-nestable pairs: all same-pair openers between open and close belong to the block
+  if (pair.nonNestable) {
+    for (let i = openIndex + 1; i < closeIndex; i++) {
+      if (pair.open.includes(matches[i].word)) {
+        blockIndices.push(i);
+      }
+    }
+  }
 
   // Add middle keywords at the same nesting level
   if (pair.middle) {
@@ -1128,6 +1148,11 @@ function findMatchingClose(
       // Special handling for dcl-ds: skip if it uses likeds() or likerec()
       if (word === 'dcl-ds' && isDclDsWithLikedsOrLikerec(text, matches[i].offset)) {
         continue; // Skip this dcl-ds, it's not a block opener
+      }
+
+      // Non-nestable pairs (CAS blocks): consecutive same-pair openers share one closer.
+      if (openingPair.nonNestable && stack.length > 0 && stack[stack.length - 1] === openingPair) {
+        continue;
       }
 
       stack.push(openingPair);
@@ -1206,6 +1231,11 @@ function findMatchingOpen(
       // Special handling for dcl-ds: skip if it uses likeds() or likerec()
       if (word === 'dcl-ds' && isDclDsWithLikedsOrLikerec(text, matches[i].offset)) {
         continue; // Skip this dcl-ds, it's not a block opener
+      }
+
+      // Non-nestable pairs (CAS blocks): keep only the first opener on the stack.
+      if (openingPair.nonNestable && stack.length > 0 && stack[stack.length - 1].pair === openingPair) {
+        continue;
       }
 
       stack.push({ index: i, pair: openingPair });

--- a/language/utils/blockParser.ts
+++ b/language/utils/blockParser.ts
@@ -2,15 +2,17 @@ export interface BlockPair {
   open: string[];
   close: string[];
   middle?: string[];
+  /** When true, consecutive openers of this pair share one closer (non-nestable). */
+  nonNestable?: boolean;
 }
 
 export const RPGLE_BLOCK_PAIRS: BlockPair[] = [
-  { open: ['if', 'ifeq', 'ifne', 'ifgt', 'iflt', 'ifge', 'ifle'], close: ['endif','end'], middle: ['else', 'elseif'] },
-  { open: ['dow', 'doweq', 'downe', 'dowgt', 'dowlt', 'dowge', 'dowle'], close: ['enddo','end'] },
-  { open: ['dou', 'doueq', 'doune', 'dougt', 'doult', 'douge', 'doule'], close: ['enddo','end'] },
-  { open: ['do'], close: ['enddo','end'] },
-  { open: ['for', 'for-each'], close: ['endfor','end'] },
-  { open: ['select'], close: ['endsl','end'], middle: ['when', 'wheneq', 'whenne', 'whengt', 'whenlt', 'whenge', 'whenle', 'when-is', 'when-in', 'other'] },
+  { open: ['if', 'ifeq', 'ifne', 'ifgt', 'iflt', 'ifge', 'ifle'], close: ['endif', 'end'], middle: ['else', 'elseif'] },
+  { open: ['dow', 'doweq', 'downe', 'dowgt', 'dowlt', 'dowge', 'dowle'], close: ['enddo', 'end'] },
+  { open: ['dou', 'doueq', 'doune', 'dougt', 'doult', 'douge', 'doule'], close: ['enddo', 'end'] },
+  { open: ['do'], close: ['enddo', 'end'] },
+  { open: ['for', 'for-each'], close: ['endfor', 'end'] },
+  { open: ['select'], close: ['endsl', 'end'], middle: ['when', 'wheneq', 'whenne', 'whengt', 'whenlt', 'whenge', 'whenle', 'when-is', 'when-in', 'other'] },
   { open: ['monitor'], close: ['endmon'], middle: ['on-error', 'on-excp'] },
   { open: ['dcl-proc'], close: ['end-proc'] },
   { open: ['dcl-ds'], close: ['end-ds'] },
@@ -18,7 +20,7 @@ export const RPGLE_BLOCK_PAIRS: BlockPair[] = [
   { open: ['dcl-pi'], close: ['end-pi'] },
   { open: ['dcl-enum'], close: ['end-enum'] },
   { open: ['begsr'], close: ['endsr'] },
-  { open: ['casxx', 'caseq', 'casne', 'casgt', 'caslt', 'casge', 'casle'], close: ['endcs'] },
+  { open: ['cas', 'casxx', 'caseq', 'casne', 'casgt', 'caslt', 'casge', 'casle'], close: ['endcs'], nonNestable: true },
 ];
 
 export interface BlockMatch {

--- a/language/utils/sqlDetection.ts
+++ b/language/utils/sqlDetection.ts
@@ -136,38 +136,102 @@ function scanForSqlTerminator(
 }
 
 /**
- * Check if a position is inside a comment or string
+ * Scan a single source line tracking string/comment state, stopping before any
+ * content that follows a `//` comment opener (when not inside a string).
+ * Returns the string state at the end of the scan.
+ * Handles RPG `''` escaped quotes (two consecutive single quotes inside a string).
+ */
+function scanLineStringState(line: string, initialInString: boolean): boolean {
+  let inString = initialInString;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (!inString) {
+      if (ch === '/' && i + 1 < line.length && line[i + 1] === '/') {
+        break; // rest of line is a comment — stop
+      }
+      if (ch === "'") {
+        inString = true;
+      }
+    } else {
+      if (ch === "'") {
+        // '' is an escaped quote inside the string — skip both characters
+        if (i + 1 < line.length && line[i + 1] === "'") {
+          i++;
+        } else {
+          inString = false;
+        }
+      }
+    }
+  }
+  return inString;
+}
+
+/**
+ * Return the string state that is carried into `lineStart` from prior
+ * continuation lines.  A string can only carry over when the preceding
+ * physical line ends with `+` (RPG free-form string continuation).
+ */
+function getPriorLineStringState(text: string, lineStart: number): boolean {
+  if (lineStart <= 0) return false;
+
+  // Find the previous physical line (skip the newline character before lineStart)
+  let prevEnd = lineStart - 1;
+  if (prevEnd > 0 && text[prevEnd - 1] === '\r') prevEnd--; // handle \r\n
+  let prevStart = prevEnd;
+  while (prevStart > 0 && text[prevStart - 1] !== '\n') {
+    prevStart--;
+  }
+
+  const prevLine = text.substring(prevStart, prevEnd);
+  // Continuation requires the last non-whitespace character to be '+'
+  if (!prevLine.trimEnd().endsWith('+')) return false;
+
+  // Recursively get the state carried into the previous line, then scan it
+  const stateBeforePrev = getPriorLineStringState(text, prevStart);
+  return scanLineStringState(prevLine, stateBeforePrev);
+}
+
+/**
+ * Check if a position is inside a comment or string.
+ * Handles RPG free-form line continuation: a string that opens on a line ending
+ * with `+` carries over into the next physical line, so keywords on continuation
+ * lines are correctly detected as being inside the string.
+ * Also correctly handles `//` that appears inside a string (e.g. 'http://...').
  * @param text The full text content
  * @param offset The position to check
  * @returns true if the position is inside a comment or string
  */
 export function isInCommentOrString(text: string, offset: number): boolean {
-  // Find the start of the line
+  // Find the start of the current physical line
   let lineStart = offset;
   while (lineStart > 0 && text[lineStart - 1] !== '\n' && text[lineStart - 1] !== '\r') {
     lineStart--;
   }
 
-  // Extract line content before the offset
+  // Carry over string state from prior continuation lines
+  let inString = getPriorLineStringState(text, lineStart);
+
+  // Scan from line start to the target offset
   const lineBeforeOffset = text.substring(lineStart, offset);
-
-  // Check if there's a comment marker before this position
-  const commentIndex = lineBeforeOffset.indexOf('//');
-  if (commentIndex !== -1) {
-    return true;
-  }
-
-  // Check if the offset is inside a string delimited by single quotes
-  let inString = false;
   for (let i = 0; i < lineBeforeOffset.length; i++) {
-    if (lineBeforeOffset[i] === "'") {
-      inString = !inString;
+    const ch = lineBeforeOffset[i];
+    if (!inString) {
+      if (ch === '/' && i + 1 < lineBeforeOffset.length && lineBeforeOffset[i + 1] === '/') {
+        return true; // position is after a line comment opener
+      }
+      if (ch === "'") {
+        inString = true;
+      }
+    } else {
+      if (ch === "'") {
+        if (i + 1 < lineBeforeOffset.length && lineBeforeOffset[i + 1] === "'") {
+          i++; // skip escaped quote pair
+        } else {
+          inString = false;
+        }
+      }
     }
   }
 
-  if (inString) {
-    return true;
-  }
-
-  return false;
+  return inString;
 }

--- a/tests/suite/blockParser.test.ts
+++ b/tests/suite/blockParser.test.ts
@@ -129,6 +129,46 @@ endfor;`;
       expect(matches[1].word).toBe('endfor');
     });
 
+    it('should find all CASxx opcodes and ENDCS in a compound CAS block', () => {
+      // Fixed-format CAS block: multiple CASxx / CAS openers share one ENDCS.
+      // All openers and the closer must appear in the matches list.
+      const code = [
+        ` c     check1        CASEQ     '1'           VALUE1`,
+        ` c     check1        CASEQ     '2'           VALUE2`,
+        ` c     check1        CASNE     '3'           VALUE3`,
+        ` c                   CAS                     VALUEEND`,
+        ` c                   ENDCS`,
+      ].join('\n');
+      const matches = findAllBlockMatches(code, isInCommentOrString, isInSqlBlock);
+      const words = matches.map(m => m.word);
+      expect(words).toContain('caseq');
+      expect(words).toContain('casne');
+      expect(words).toContain('cas');
+      expect(words).toContain('endcs');
+      // No stray block keywords should appear
+      expect(words.filter(w => !['caseq', 'casne', 'cas', 'endcs'].includes(w))).toHaveLength(0);
+    });
+
+    it('should not count IF inside a string literal spanning continuation lines', () => {
+      // 'if' appears on the continuation line of a string — must not be a block match.
+      // blockParser returns 'end' (not 'end-proc') because its regex is not longest-first.
+      const code = [
+        `dcl-proc set_msg;`,
+        `  dcl-s msg varchar(100);`,
+        `  msg = 'Let me know if you are ready to proceed.';`,
+        `  msg = 'Let me +`,
+        `           know if you are ready to proceed.';`,
+        `  msg = 'Let me ' +`,
+        `           'know if you are ready to proceed.';`,
+        `end-proc;`,
+      ].join('\n');
+      const matches = findAllBlockMatches(code, isInCommentOrString, isInSqlBlock);
+      const words = matches.map(m => m.word);
+      // No 'if' should appear — all three occurrences are inside string literals
+      expect(words).not.toContain('if');
+      expect(words).toContain('dcl-proc');
+    });
+
     it('should find DCL-PROC blocks', () => {
       const code = `dcl-proc myProc;
   dcl-pi *n;

--- a/tests/suite/sqlDetection.test.ts
+++ b/tests/suite/sqlDetection.test.ts
@@ -195,6 +195,35 @@ if x > 0;`;
       const offset = code.indexOf('unclosed');
       expect(isInCommentOrString(code, offset)).to.be.true;
     });
+
+    it('should detect keyword on continuation line inside string literal', () => {
+      // The string opens on the first line (ends with + inside the string).
+      // 'if' on the second line is still inside the string.
+      const code = `msg = 'Let me +\n                  know if you are ready to proceed.';`;
+      const offset = code.indexOf('know if') + 'know '.length;
+      expect(isInCommentOrString(code, offset)).to.be.true;
+    });
+
+    it('should detect keyword on third continuation line', () => {
+      const code = `msg = 'part1 +\n       part2 +\n       endif rest';`;
+      const offset = code.lastIndexOf('endif');
+      expect(isInCommentOrString(code, offset)).to.be.true;
+    });
+
+    it('should not misidentify keyword after separate string on continuation line', () => {
+      // The first line closes its string before the +, so the second line starts fresh.
+      // 'if' on the second line is inside its own new string literal.
+      const code = `msg = 'Let me ' +\n                  'know if you are ready to proceed.';`;
+      const offset = code.indexOf('know if') + 'know '.length;
+      expect(isInCommentOrString(code, offset)).to.be.true;
+    });
+
+    it('should not flag code after a string containing //', () => {
+      // // inside a completed string should not be treated as a line comment
+      const code = `msg = 'http://example.com'; if (x > 0);`;
+      const offset = code.indexOf(' if ') + 1;
+      expect(isInCommentOrString(code, offset)).to.be.false;
+    });
   });
 
   describe('integration tests', () => {


### PR DESCRIPTION
Two bracket-matching edge-case fixes reported by users after the recent bracket-highlighting release.

---

## Fix 1 — Keywords inside RPG string literals spanning continuation lines

**Problem:** `isInCommentOrString` in `language/utils/sqlDetection.ts` only examined the current physical line. In RPG free-form, a string literal can continue across lines via a trailing `+`:

```rpg
msg = 'Let me +
         know if you are ready to proceed.';
```

On the continuation line, `if` appears before any quote character, so `isInCommentOrString` returned `false` — treating the `if` inside the string as a real block opener. This caused `end-proc` (and other closers) to be highlighted in red as mismatched.

**Fix:** Added `getPriorLineStringState` which walks backwards through `+`-terminated lines carrying the string open/close state, and `scanLineStringState` for a single-pass scan that correctly handles `''` escaped quotes and `//` line comments. The same change also fixes a secondary bug where `//` appearing inside a completed string literal (e.g. `'http://...'`) was falsely flagged as a line-comment start for code that followed on the same line.

All three patterns from the reported example are now correctly handled:
```rpg
msg = 'Let me know if you are ready to proceed.';         //  was already working
msg = 'Let me +
         know if you are ready to proceed.';              //  fixed
msg = 'Let me ' +
         'know if you are ready to proceed.';             //  was already working
```

**Files changed:** `language/utils/sqlDetection.ts`, `tests/suite/sqlDetection.test.ts`

---

## Fix 2 — CASxx compound block highlighting

**Problem:** In fixed-format RPG, a `CAS` block consists of multiple `CASxx`/`CAS` openers that all share a single `ENDCS` closer:

```rpg
C     check1        CASEQ     '1'           VALUE1
C     check1        CASEQ     '2'           VALUE2
C     check1        CASNE     '3'           VALUE3
C                   CAS                     VALUEEND
C                   ENDCS
```

The matcher treated each `CASxx` as an independent nested opener, so the stack grew to depth N before the single `ENDCS` was seen — causing `findMatchingClose` to return -1 for all but the last opener. Clicking the first `CASEQ` produced no highlight; clicking `ENDCS` highlighted only the last `CASEQ`. The bare `CAS` opcode was also missing from the keyword list entirely.

**Fix:**
- Added `nonNestable?: boolean` to the `BlockPair` interface in `blockParser.ts`
- Added `'cas'` to the CAS pair's open list; marked the pair `nonNestable: true`
- `findMatchingClose`: when the stack top is already an active non-nestable pair, skip subsequent same-pair openers instead of pushing them
- `findMatchingOpen`: same guard, ensuring `ENDCS` maps back to the *first* opener
- `findBlockIndices`: for non-nestable openers, scans backward to find the first opener in the run, then includes all intermediate same-pair openers in the highlighted set

**Result:** Clicking any `CASxx`/`CAS` or `ENDCS` highlights the entire compound block together.

**Files changed:** `language/utils/blockParser.ts`, `extension/client/src/language/bracketMatcher.ts`, `tests/suite/blockParser.test.ts`